### PR TITLE
Rip option using backup method in MakeMKV and main-feature in HandBrake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ logs/*
 test.sh
 archive/
 config
-
+temp/

--- a/config.sample
+++ b/config.sample
@@ -27,6 +27,13 @@ LOGLIFE=1
 #Minimum length of track for MakeMKV rip (in seconds)
 MINLENGTH="600"
 
+#Method of MakeMKV to use for Blu Ray discs.  Options are "mkv" or "backup".
+#mkv is the normal method of ripping mkv files directly from the DVD
+#backup decrypts the dvd and then copies it to the hard drive.  This allows HandBrake to apply some of it's
+#analytical abilities such as the main-feature identification.  This method seems to offer success on bluray 
+#discs that fail in "mkv" mode. *** NOTE: MakeMKV only supports the backup method on BluRay discs.  Regular
+#DVD's will always default back to the "mkv" mode. 
+RIPMETHOD="backup" 
 
 ##########################
 ## HandBrake Parameters ##
@@ -42,13 +49,22 @@ DEST_EXT=mkv
 #Handbrake binary to call
 HANDBRAKE_CLI=HandBrakeCLI
 
+#Have HandBrake transcode the main feature only.  BluRay discs must have RIPMETHOD="backup" for this to work.
+#If MAINFEATURE is true, blurays will be backed up to the HD and then HandBrake will go to work on the backed up
+#files.  For normal DVDs, ARM will by pass MakeMKV and be accessed directly by HandBrake.  This will require 
+#libdvdcss2 be installed.
+#NOTE: For the most part, HandBrake correctly identifies the main feature on movie DVD's, although it is not perfect. 
+#However, it does not handle tv shows well at all.  You will likely want this value to be false when ripping tv shows.
+#MAINFEATURE=false
+MAINFEATURE=false
+
 #############################
 ## Notification Parameters ##
 #############################
 
 #Pushbullet API Key
 #Leave empty or comment out to disable Pushbullet notifications
-#PB_KEY=""
+PB_KEY=""
 
 #IFTTT API KEY
 #Leave empty or comment out to disable IFTTT notifications

--- a/video_rip.sh
+++ b/video_rip.sh
@@ -12,14 +12,26 @@ source /opt/arm/config
 	RIPSTART=$(date +%s);
         mkdir $DEST
 
+	if [ $RIPMETHOD = "backup" ] && [ $ID_CDROM_MEDIA_BD = "1" ]; then
+		echo "Using backup method of ripping." >> $LOG
+		DISC="${DEVNAME: -1}"
+		echo "Sending command: "makemkvcon backup --decrypt -r disc:$DISC $DEST/""
+		makemkvcon backup --decrypt -r disc:$DISC $DEST/
+		eject $DEVNAME
+	elif [ $MAINFEATURE = true ] && [ $ID_CDROM_MEDIA_DVD = "1" ] && [ -z $ID_CDROM_MEDIA_BD ]; then
+		echo "Media is DVD and Main Feature parameter in config file is true.  Bypassing MakeMKV." >> $LOG
 
-	makemkvcon mkv dev:$DEVNAME all $DEST --minlength=$MINLENGTH -r
+	else
+		echo "Using mkv method of ripping." >> $LOG
+		makemkvcon mkv dev:$DEVNAME all $DEST --minlength=$MINLENGTH -r
+		eject $DEVNAME
+	fi
 
 	RIPEND=$(date +%s);
 	RIPSEC=$(($RIPEND-$RIPSTART));
 	RIPTIME="$(($RIPSEC / 3600)) hours, $((($RIPSEC / 60) % 60)) minutes and $(($RIPSEC % 60)) seconds."
 
-	eject $DEVNAME
+	#eject $DEVNAME
 
 	echo /opt/arm/notify.sh "\"Ripped: ${ID_FS_LABEL} completed from ${DEVNAME} in ${RIPTIME}\"" |at now
 

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -51,7 +51,7 @@ TRANSTIME="$(($TRANSSEC / 3600)) hours, $((($TRANSSEC / 60) % 60)) minutes and $
 
 echo "STAT: ${ID_FS_LABEL} transcoded in ${TRANSTIME}" >> $LOG
 
-echo /opt/arm/rename.sh $DEST
+#echo /opt/arm/rename.sh $DEST
 
 echo /opt/arm/notify.sh "\"Transcode: ${ID_FS_LABEL} completed in ${TRANSTIME}\"" |at now
 

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -8,6 +8,7 @@ LABEL=$2
 TIMESTAMP=$3
 TRANSSTART=$(date +%s);
 
+
 echo "Start video transcoding script" >> $LOG
 
 	DEST=${ARMPATH}/${LABEL}_${TIMESTAMP}
@@ -16,6 +17,10 @@ echo "Start video transcoding script" >> $LOG
 	if [ $RIPMETHOD = "backup" ] && [ "$MAINFEATURE" = true ] && [ $ID_CDROM_MEDIA_BD = "1" ]; then
 		echo "Transcoding BluRay main feature only." >> $LOG
 		$HANDBRAKE_CLI -i $SRC -o $DEST/$LABEL.$DEST_EXT --main-feature --preset="$HB_PRESET" --subtitle scan -F 2>> $LOG
+		rmdir -rf $SRC
+	elif [ $RIPMETHOD = "backup" ] && [ "$MAINFEATURE" = false ] && [ $ID_CDROM_MEDIA_BD = "1" ]; then
+		echo "Transcoding BluRay all titles above minlength." >> $LOG
+		$HANDBRAKE_CLI -i $SRC -o $DEST/$LABEL.$DEST_EXT --min-duration $MINLENGTH --preset="$HB_PRESET" --subtitle scan -F 2>> $LOG
 		rmdir -rf $SRC
 	elif [ $MAINFEATURE = true ] && [ $ID_CDROM_MEDIA_DVD = "1" ]; then
 		echo "Transcoding DVD main feature only." >> $LOG
@@ -46,6 +51,7 @@ TRANSTIME="$(($TRANSSEC / 3600)) hours, $((($TRANSSEC / 60) % 60)) minutes and $
 
 echo "STAT: ${ID_FS_LABEL} transcoded in ${TRANSTIME}" >> $LOG
 
+echo /opt/arm/rename.sh $DEST
+
 echo /opt/arm/notify.sh "\"Transcode: ${ID_FS_LABEL} completed in ${TRANSTIME}\"" |at now
 
-echo /opt/arm/rename.sh $DEST

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -13,23 +13,32 @@ echo "Start video transcoding script" >> $LOG
 	DEST=${ARMPATH}/${LABEL}_${TIMESTAMP}
 	mkdir $DEST
 
-        for FILE in `ls $SRC`
-                do
-                filename=$(basename $FILE)
-                extension=${filename##*.}
-                filename=${filename%.*}
-	
-		echo "Transcoding file $FILE" >> $LOG
+	if [ $RIPMETHOD = "backup" ] && [ "$MAINFEATURE" = true ] && [ $ID_CDROM_MEDIA_BD = "1" ]; then
+		echo "Transcoding BluRay main feature only." >> $LOG
+		$HANDBRAKE_CLI -i $SRC -o $DEST/$LABEL.$DEST_EXT --main-feature --preset="$HB_PRESET" --subtitle scan -F 2>> $LOG
+		rmdir -rf $SRC
+	elif [ $MAINFEATURE = true ] && [ $ID_CDROM_MEDIA_DVD = "1" ]; then
+		echo "Transcoding DVD main feature only." >> $LOG
+                $HANDBRAKE_CLI -i $DEVNAME -o $DEST/$LABEL.$DEST_EXT --main-feature --preset="$HB_PRESET" --subtitle scan -F 2>> $LOG
+		eject $DEVNAME
+		rmdir $SRC
+	else
+		echo "Transcoding all files." >> $LOG
+	        for FILE in `ls $SRC`
+                	do
+                	filename=$(basename $FILE)
+                	extension=${filename##*.}
+                	filename=${filename%.*}
 
-                $HANDBRAKE_CLI -i $SRC/$FILE -o $DEST/$filename.$DEST_EXT --preset="$HB_PRESET" --subtitle scan -F 2>> $LOG
-		#TIMESTAMP=`date '+%Y_%m_%d__%H_%M_%S'`;
-		#mv $SRC/$FILE $SRC/done/$TIMESTAMP.$FILE
-		#mv $DEST/$FILE $DEST/done/$FILE
-		rm $SRC/$FILE
+			echo "Transcoding file $FILE" >> $LOG
 
-       	done
+                	$HANDBRAKE_CLI -i $SRC/$FILE -o $DEST/$filename.$DEST_EXT --preset="$HB_PRESET" --subtitle scan -F 2>> $LOG
+			rm $SRC/$FILE
+       		done
+		rmdir $SRC
+	fi
 
-rmdir $SRC
+#rmdir $SRC
 
 TRANSEND=$(date +%s);
 TRANSSEC=$(($TRANSEND-$TRANSSTART));
@@ -39,3 +48,4 @@ echo "STAT: ${ID_FS_LABEL} transcoded in ${TRANSTIME}" >> $LOG
 
 echo /opt/arm/notify.sh "\"Transcode: ${ID_FS_LABEL} completed in ${TRANSTIME}\"" |at now
 
+echo /opt/arm/rename.sh $DEST


### PR DESCRIPTION
**Option to use "backup" method in MakeMKV.**  Using backup method decrypts and copies the Bluray file structure to HD.  This offers two potential advantages: less errors and the ability to use the --main-feature switch in HandBrake to identify the main title and rip only that title. Note: MakeMKV only supports "backup" method on Bluray.
**Also added the option to pass the --main-feature switch to HandBrakeCLI** (param in config file).  If a Bluray is ripped using the backup method and the main feature param is true, HandBrake will be pointed at the freshly created backup and attempt to find the main title and rip only that title.  If a DVD is found and the main title param is set, MakeMKV is bypassed and HandBrake is pointed directly at the DVD.  Note: This requires libdvdcss2 be installed.  In Ubuntu 15.04 and newer that can easily be down with "sudo apt-get install libdvd-pkg" and following the instructions. 
