### PR TITLE
Add makemkv profile for controlling makemkv audio/subtitle selection

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -54,6 +54,12 @@ MINLENGTH="600"
 # DVD's will always default back to the "mkv" mode. If this is set to "backup" then you must also set HandBrake's MAINFEATURE to true. 
 RIPMETHOD="mkv" 
 
+# MakeMKV Profile used for controlling Audio Track Selection.
+# This is the default profile MakeMKV uses for Audio track selection. Updating this file or changing it is considered
+# to be advanced usage of MakeMKV. But this will allow users to alternatively tell makemkv to select HD audio tracks and etc.
+MAKEMKVPROFILE_FILE="/opt/arm/default.mmcp.xml"
+
+
 ##########################
 ## HandBrake Parameters ##
 ##########################

--- a/default.mmcp.xml
+++ b/default.mmcp.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<profile>
+    <!-- profile name - Default -->
+    <name lang="mogz">:5086</name>
+
+    <!-- Common MKV flags -->
+    <mkvSettings 
+        ignoreForcedSubtitlesFlag="true"
+        useISO639Type2T="false"
+        setFirstAudioTrackAsDefault="true"
+        setFirstSubtitleTrackAsDefault="true"
+        setFirstForcedSubtitleTrackAsDefault="true"
+        insertFirstChapter00IfMissing="true"
+    />
+
+    <!-- Settings overridable in preferences -->
+    <profileSettings
+        app_DefaultSelectionString="-sel:all,+sel:(favlang|nolang|single),-sel:(havemulti|havecore),-sel:mvcvideo,=100:all,-10:favlang"
+    />
+
+    <!-- Output formats currently supported by MakeMKV -->
+    <outputSettings name="copy" outputFormat="directCopy">
+        <description lang="eng">Copy track as is</description>
+        <description lang="ger">Track 1:1 kopieren</description>
+    </outputSettings>
+
+    <outputSettings name="lpcm" outputFormat="LPCM-raw">
+        <description lang="eng">Save as raw LPCM</description>
+        <description lang="ger">Als RAW LPCM speichern</description>
+    </outputSettings>
+
+    <outputSettings name="wavex" outputFormat="LPCM-wavex">
+        <description lang="eng">Save as LPCM in WAV container</description>
+        <description lang="ger">Als LPCM im WAV-Container speichern</description>
+    </outputSettings>
+
+    <outputSettings name="flac-best" outputFormat="FLAC">
+        <description lang="eng">Save as FLAC (best compression)</description>
+        <description lang="ger">Als FLAC speichern (höchste Komprimierungsstufe)</description>
+        <extraArgs>-compression_level 12</extraArgs>
+    </outputSettings>
+
+    <outputSettings name="flac-fast" outputFormat="FLAC">
+        <description lang="eng">Save as FLAC (fast compression)</description>
+        <extraArgs>-compression_level 5</extraArgs>
+    </outputSettings>
+
+    <!-- Default rule - copy as is -->
+    <trackSettings input="default">
+        <output outputSettingsName="copy" 
+                defaultSelection="$app_DefaultSelectionString">
+        </output>
+    </trackSettings>
+
+    <!-- Save LPCM mono or stereo as raw LPCM -->
+    <trackSettings input="LPCM-stereo">
+        <output outputSettingsName="lpcm"
+                defaultSelection="$app_DefaultSelectionString">
+        </output>
+    </trackSettings>
+
+    <!-- Put multi-channel LPCM into WAVEX container-->
+    <trackSettings input="LPCM-multi">
+        <output outputSettingsName="wavex"
+                defaultSelection="$app_DefaultSelectionString">
+        </output>
+    </trackSettings>
+
+</profile>

--- a/video_rip.sh
+++ b/video_rip.sh
@@ -15,6 +15,7 @@ VIDEO_TYPE=$3
  	echo "Ripping video ${ID_FS_LABEL} from ${DEVNAME}" >> "$LOG"
 	TIMESTAMP=$(date '+%Y%m%d_%H%M%S');
 	DEST="${RAWPATH}/${VIDEO_TITLE}_${TIMESTAMP}"
+	PROFILE="--profile=/${MAKEMKVPROFILE_FILE}"
 	RIPSTART=$(date +%s);
     
 	mkdir "$DEST"
@@ -24,7 +25,7 @@ VIDEO_TYPE=$3
 		echo "Using backup method of ripping." >> "$LOG"
 		DISC="${DEVNAME: -1}"
 		echo "Sending command: makemkvcon backup --decrypt -r disc:$DISC $DEST"
-		makemkvcon backup --decrypt -r disc:"$DISC" "$DEST"/
+		makemkvcon $PROFILE backup --decrypt -r disc:"$DISC" "$DEST"/
 		eject "$DEVNAME"
 	elif [ "$MAINFEATURE" = true ] && [ "$ID_CDROM_MEDIA_DVD" = "1" ] && [ -z "$ID_CDROM_MEDIA_BD" ]; then
 		echo "Media is DVD and Main Feature parameter in config file is true.  Bypassing MakeMKV." >> "$LOG"
@@ -33,7 +34,7 @@ VIDEO_TYPE=$3
 	echo "DEST is ${DEST}"
 	else
 		echo "Using mkv method of ripping." >> "$LOG"
-		makemkvcon mkv dev:"$DEVNAME" all "$DEST" --minlength="$MINLENGTH" -r
+		makemkvcon $PROFILE mkv dev:"$DEVNAME" all "$DEST" --minlength="$MINLENGTH" -r
 		eject "$DEVNAME"
 	fi
 

--- a/video_rip.sh
+++ b/video_rip.sh
@@ -25,7 +25,7 @@ VIDEO_TYPE=$3
 		echo "Using backup method of ripping." >> "$LOG"
 		DISC="${DEVNAME: -1}"
 		echo "Sending command: makemkvcon backup --decrypt -r disc:$DISC $DEST"
-		makemkvcon $PROFILE backup --decrypt -r disc:"$DISC" "$DEST"/
+		makemkvcon "$PROFILE" backup --decrypt -r disc:"$DISC" "$DEST"/
 		eject "$DEVNAME"
 	elif [ "$MAINFEATURE" = true ] && [ "$ID_CDROM_MEDIA_DVD" = "1" ] && [ -z "$ID_CDROM_MEDIA_BD" ]; then
 		echo "Media is DVD and Main Feature parameter in config file is true.  Bypassing MakeMKV." >> "$LOG"
@@ -34,7 +34,7 @@ VIDEO_TYPE=$3
 	echo "DEST is ${DEST}"
 	else
 		echo "Using mkv method of ripping." >> "$LOG"
-		makemkvcon $PROFILE mkv dev:"$DEVNAME" all "$DEST" --minlength="$MINLENGTH" -r
+		makemkvcon "$PROFILE" mkv dev:"$DEVNAME" all "$DEST" --minlength="$MINLENGTH" -r
 		eject "$DEVNAME"
 	fi
 


### PR DESCRIPTION
I am currently using parts of this in my own setup. I've implemented this in my own setup so I could customize the profile used by Makemkv to ensure HD audio is selected when ripping to non-compressed MKV rips. This needs to be thoroughly tested... The part that is untested is using variables to pass the config file path and the augmentation of the makemkvcon command using variables. I currently have this working in my setup strictly using the intended output without any configuration via variables.