### PR TITLE
Updating extra Folders to support Plex

### DIFF
--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -169,16 +169,37 @@ TIMESTAMP=$5
 		fi
 
 		#now move "extras"
-		# shellcheck disable=SC2129,SC2016
-		mkdir -v "$MEDIA_DIR/$LABEL/extras" >> "$LOG"
-		# shellcheck disable=SC2086
-        echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/extras/\""" >> "$LOG"
-        mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/extras/" >> "$LOG"
-		if [ "$EMBY_REFRESH" = true ]; then
-			# signal emby to scan library
-			embyrefresh
+		if [ "PLEX_SUPPORT" = true ]; then
+		
+			# shellcheck disable=SC2129,SC2016
+			mkdir -v "$MEDIA_DIR/$LABEL/Featurettes" >> "$LOG"
+			
+			# Create Emby ignore file for "extras" Folder
+			touch $MEDIA_DIR/$LABEL/Featurettes/.ignore
+			
+			# shellcheck disable=SC2086
+       			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/Featurettes/\""" >> "$LOG"
+       			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/Featurettes/" >> "$LOG"
+				
 		else
-			echo "Emby Refresh False.  Skipping library scan" >> "$LOG"
+				
+			# shellcheck disable=SC2129,SC2016
+			mkdir -v "$MEDIA_DIR/$LABEL/extras" >> "$LOG"
+				
+			# Create Plex ignore file for "extras" Folder
+			touch $MEDIA_DIR/$LABEL/extras/.plexignore
+			
+			# shellcheck disable=SC2086
+      			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/extras/\""" >> "$LOG"
+       			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/extras/" >> "$LOG"
+			
+			if [ "$EMBY_REFRESH" = true ]; then
+				# signal emby to scan library
+					embyrefresh
+			else
+					echo "Emby Refresh False.  Skipping library scan" >> "$LOG"
+			fi
+				
 		fi
 		rmdir "$DEST"
 	fi


### PR DESCRIPTION
Going to add a system wide variable that can be turned on to create the folder needed for Plex Extras Support. If it is not enabled, it will default to how Emby wants it, but add a ".plexignore" file to the extras folder. This will allow you to use both Plex and Emby at the same time. Same thing if you enable Plex Support, an ".ignore" file will be added to the Plex Featurettes folder to tell Emby to ignore those files since it does not match its naming convention..