### PR TITLE
Add Plex Support

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -30,7 +30,7 @@ RAWPATH="/mnt/media/ARM/raw/"
 
 # Path to final media directory
 # Destination for final file.  Only used for movies that are positively identified
-MEDIA_DIR="/mnt/media/ARM/emby/movies/"
+MEDIA_DIR="/mnt/media/ARM/Media/Movies/"
 
 # Path to directory to hold log files
 # Make sure to include trailing /
@@ -75,6 +75,13 @@ HANDBRAKE_CLI=HandBrakeCLI
 # NOTE: For the most part, HandBrake correctly identifies the main feature on movie DVD's, although it is not perfect. 
 # However, it does not handle tv shows well at all.  You will likely want this value to be false when ripping tv shows.
 MAINFEATURE=false
+
+#####################
+## Enable Plex Use ##
+#####################
+
+# Set this setting to true, to enable Plex Extras support
+PLEX_SUPPORT=false
 
 #####################
 ## Emby Parameters ##

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -169,16 +169,37 @@ TIMESTAMP=$5
 		fi
 
 		#now move "extras"
-		# shellcheck disable=SC2129,SC2016
-		mkdir -v "$MEDIA_DIR/$LABEL/extras" >> "$LOG"
-		# shellcheck disable=SC2086
-        echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/extras/\""" >> "$LOG"
-        mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/extras/" >> "$LOG"
-		if [ "$EMBY_REFRESH" = true ]; then
-			# signal emby to scan library
-			embyrefresh
+		if [ "PLEX_SUPPORT" = true ]; then
+		
+			# shellcheck disable=SC2129,SC2016
+			mkdir -v "$MEDIA_DIR/$LABEL/Featurettes" >> "$LOG"
+			
+			# Create Emby ignore file for "extras" Folder
+			touch $MEDIA_DIR/$LABEL/Featurettes/.ignore
+			
+			# shellcheck disable=SC2086
+       			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/Featurettes/\""" >> "$LOG"
+       			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/Featurettes/" >> "$LOG"
+				
 		else
-			echo "Emby Refresh False.  Skipping library scan" >> "$LOG"
+				
+			# shellcheck disable=SC2129,SC2016
+			mkdir -v "$MEDIA_DIR/$LABEL/extras" >> "$LOG"
+				
+			# Create Plex ignore file for "extras" Folder
+			touch $MEDIA_DIR/$LABEL/extras/.plexignore
+			
+			# shellcheck disable=SC2086
+      			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/extras/\""" >> "$LOG"
+       			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/extras/" >> "$LOG"
+			
+			if [ "$EMBY_REFRESH" = true ]; then
+				# signal emby to scan library
+					embyrefresh
+			else
+					echo "Emby Refresh False.  Skipping library scan" >> "$LOG"
+			fi
+				
 		fi
 		rmdir "$DEST"
 	fi

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -169,13 +169,13 @@ TIMESTAMP=$5
 		fi
 
 		#now move "extras"
-		if [ "PLEX_SUPPORT" = true ]; then
+		if [ "$PLEX_SUPPORT" = true ]; then
 		
 			# shellcheck disable=SC2129,SC2016
 			mkdir -v "$MEDIA_DIR/$LABEL/Featurettes" >> "$LOG"
 			
 			# Create Emby ignore file for "extras" Folder
-			touch $MEDIA_DIR/$LABEL/Featurettes/.ignore
+			touch "$MEDIA_DIR/$LABEL/Featurettes/.ignore"
 			
 			# shellcheck disable=SC2086
        			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/Featurettes/\""" >> "$LOG"
@@ -187,7 +187,7 @@ TIMESTAMP=$5
 			mkdir -v "$MEDIA_DIR/$LABEL/extras" >> "$LOG"
 				
 			# Create Plex ignore file for "extras" Folder
-			touch $MEDIA_DIR/$LABEL/extras/.plexignore
+			touch "$MEDIA_DIR/$LABEL/extras/.plexignore"
 			
 			# shellcheck disable=SC2086
       			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/extras/\""" >> "$LOG"


### PR DESCRIPTION
This adds additional configuration to enable usage with Plex, by default this script is built to work with Emby after it's most recent updates. This update enables proper use with Plex, by creating the directories necessary for Extras. This will also enable dual use, by creating the proper files for both Plex and Emby to pull from the same directories, encase one is running both applications at the same time...

Please review my code thoroughly, as I am a bit of a novice when it comes to these things.... I am primarily a Plex user, that is why I made this patch and it would be beneficial to others...