### PR TITLE
Added MakeMKV Profile, Plex and Main movie Support

### DIFF
--- a/.abcde.conf
+++ b/.abcde.conf
@@ -63,7 +63,7 @@ CDPARANOIAOPTS="--never-skip=40"
 CDDISCID=cd-discid            
                                
 # Give the base location here for the encoded music files.
-OUTPUTDIR="/mnt/media/ARM/"               
+OUTPUTDIR="~/ARM/Media/Music"               
 
 # The default actions that abcde will take.
 ACTIONS=cddb,playlist,getalbumart,read,encode,tag,move,clean

--- a/.abcde.conf
+++ b/.abcde.conf
@@ -63,26 +63,26 @@ CDPARANOIAOPTS="--never-skip=40"
 CDDISCID=cd-discid            
                                
 # Give the base location here for the encoded music files.
-OUTPUTDIR="/mnt/media/ARM/Media/Music/"               
+OUTPUTDIR="/mnt/media/ARM/"               
 
 # The default actions that abcde will take.
-ACTIONS=cddb,playlist,getalbumart,read,encode,replaygain,tag,move,clean
+ACTIONS=cddb,playlist,getalbumart,read,encode,tag,move,clean
               
 # Decide here how you want the tracks labelled for a standard 'single-artist',
 # multi-track encode and also for a multi-track, 'various-artist' encode:
 OUTPUTFORMAT='${OUTPUT}/${ARTISTFILE}/${ALBUMFILE}/${TRACKNUM}.${TRACKFILE}'
-VAOUTPUTFORMAT='${OUTPUT}/Various Artists/${ALBUMFILE}/${TRACKNUM}.${ARTISTFILE}-${TRACKFILE}'
+VAOUTPUTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${TRACKNUM}.${ARTISTFILE}-${TRACKFILE}'
 
 # Decide here how you want the tracks labelled for a standard 'single-artist',
 # single-track encode and also for a single-track 'various-artist' encode.
 # (Create a single-track encode with 'abcde -1' from the commandline.)
 ONETRACKOUTPUTFORMAT='${OUTPUT}/${ARTISTFILE}/${ALBUMFILE}/${ALBUMFILE}'
-VAONETRACKOUTPUTFORMAT='${OUTPUT}/Various Artists/${ALBUMFILE}/${ALBUMFILE}'
+VAONETRACKOUTPUTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${ALBUMFILE}'
 
 # Create playlists for single and various-artist encodes. I would suggest
 # commenting these out for single-track encoding.
 PLAYLISTFORMAT='${OUTPUT}/${ARTISTFILE}/${ALBUMFILE}/${ALBUMFILE}.m3u'
-VAPLAYLISTFORMAT='${OUTPUT}/Various Artists/${ALBUMFILE}/${ALBUMFILE}.m3u'
+VAPLAYLISTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${ALBUMFILE}.m3u'
 
 # This function takes out dots preceding the album name, and removes a grab
 # bag of illegal characters. It allows spaces, if you do not wish spaces add

--- a/.abcde.conf
+++ b/.abcde.conf
@@ -63,7 +63,7 @@ CDPARANOIAOPTS="--never-skip=40"
 CDDISCID=cd-discid            
                                
 # Give the base location here for the encoded music files.
-OUTPUTDIR="~/ARM/Media/Music"               
+OUTPUTDIR="/mnt/media/ARM/Media/Music"               
 
 # The default actions that abcde will take.
 ACTIONS=cddb,playlist,getalbumart,read,encode,replaygain,tag,move,clean

--- a/.abcde.conf
+++ b/.abcde.conf
@@ -63,26 +63,26 @@ CDPARANOIAOPTS="--never-skip=40"
 CDDISCID=cd-discid            
                                
 # Give the base location here for the encoded music files.
-OUTPUTDIR="/mnt/media/ARM/"               
+OUTPUTDIR="/mnt/media/ARM/Media/Music/"               
 
 # The default actions that abcde will take.
-ACTIONS=cddb,playlist,getalbumart,read,encode,tag,move,clean
+ACTIONS=cddb,playlist,getalbumart,read,encode,replaygain,tag,move,clean
               
 # Decide here how you want the tracks labelled for a standard 'single-artist',
 # multi-track encode and also for a multi-track, 'various-artist' encode:
 OUTPUTFORMAT='${OUTPUT}/${ARTISTFILE}/${ALBUMFILE}/${TRACKNUM}.${TRACKFILE}'
-VAOUTPUTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${TRACKNUM}.${ARTISTFILE}-${TRACKFILE}'
+VAOUTPUTFORMAT='${OUTPUT}/Various Artists/${ALBUMFILE}/${TRACKNUM}.${ARTISTFILE}-${TRACKFILE}'
 
 # Decide here how you want the tracks labelled for a standard 'single-artist',
 # single-track encode and also for a single-track 'various-artist' encode.
 # (Create a single-track encode with 'abcde -1' from the commandline.)
 ONETRACKOUTPUTFORMAT='${OUTPUT}/${ARTISTFILE}/${ALBUMFILE}/${ALBUMFILE}'
-VAONETRACKOUTPUTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${ALBUMFILE}'
+VAONETRACKOUTPUTFORMAT='${OUTPUT}/Various Artists/${ALBUMFILE}/${ALBUMFILE}'
 
 # Create playlists for single and various-artist encodes. I would suggest
 # commenting these out for single-track encoding.
 PLAYLISTFORMAT='${OUTPUT}/${ARTISTFILE}/${ALBUMFILE}/${ALBUMFILE}.m3u'
-VAPLAYLISTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${ALBUMFILE}.m3u'
+VAPLAYLISTFORMAT='${OUTPUT}/Various Artists/${ALBUMFILE}/${ALBUMFILE}.m3u'
 
 # This function takes out dots preceding the album name, and removes a grab
 # bag of illegal characters. It allows spaces, if you do not wish spaces add

--- a/.abcde.conf
+++ b/.abcde.conf
@@ -63,7 +63,7 @@ CDPARANOIAOPTS="--never-skip=40"
 CDDISCID=cd-discid            
                                
 # Give the base location here for the encoded music files.
-OUTPUTDIR="/mnt/media/ARM/Media/Music"               
+OUTPUTDIR="/mnt/media/ARM/Media/Music/"               
 
 # The default actions that abcde will take.
 ACTIONS=cddb,playlist,getalbumart,read,encode,replaygain,tag,move,clean

--- a/.abcde.conf
+++ b/.abcde.conf
@@ -71,18 +71,18 @@ ACTIONS=cddb,playlist,getalbumart,read,encode,tag,move,clean
 # Decide here how you want the tracks labelled for a standard 'single-artist',
 # multi-track encode and also for a multi-track, 'various-artist' encode:
 OUTPUTFORMAT='${OUTPUT}/${ARTISTFILE}/${ALBUMFILE}/${TRACKNUM}.${TRACKFILE}'
-VAOUTPUTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${TRACKNUM}.${ARTISTFILE}-${TRACKFILE}'
+VAOUTPUTFORMAT='${OUTPUT}/Various Artists/${ALBUMFILE}/${TRACKNUM}.${ARTISTFILE}-${TRACKFILE}'
 
 # Decide here how you want the tracks labelled for a standard 'single-artist',
 # single-track encode and also for a single-track 'various-artist' encode.
 # (Create a single-track encode with 'abcde -1' from the commandline.)
 ONETRACKOUTPUTFORMAT='${OUTPUT}/${ARTISTFILE}/${ALBUMFILE}/${ALBUMFILE}'
-VAONETRACKOUTPUTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${ALBUMFILE}'
+VAONETRACKOUTPUTFORMAT='${OUTPUT}/Various Artists/${ALBUMFILE}/${ALBUMFILE}'
 
 # Create playlists for single and various-artist encodes. I would suggest
 # commenting these out for single-track encoding.
 PLAYLISTFORMAT='${OUTPUT}/${ARTISTFILE}/${ALBUMFILE}/${ALBUMFILE}.m3u'
-VAPLAYLISTFORMAT='${OUTPUT}/Various-${ALBUMFILE}/${ALBUMFILE}.m3u'
+VAPLAYLISTFORMAT='${OUTPUT}/Various Artists/${ALBUMFILE}/${ALBUMFILE}.m3u'
 
 # This function takes out dots preceding the album name, and removes a grab
 # bag of illegal characters. It allows spaces, if you do not wish spaces add

--- a/.abcde.conf
+++ b/.abcde.conf
@@ -66,7 +66,7 @@ CDDISCID=cd-discid
 OUTPUTDIR="~/ARM/Media/Music"               
 
 # The default actions that abcde will take.
-ACTIONS=cddb,playlist,getalbumart,read,encode,tag,move,clean
+ACTIONS=cddb,playlist,getalbumart,read,encode,replaygain,tag,move,clean
               
 # Decide here how you want the tracks labelled for a standard 'single-artist',
 # multi-track encode and also for a multi-track, 'various-artist' encode:

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ See: https://b3n.org/automatic-ripping-machine
     sudo apt install python3 python3-pip
     sudo apt-get install libdvd-pkg
     sudo dpkg-reconfigure libdvd-pkg
-    mkdir -p ~/ARM/raw
-    mkdir -p ~/ARM/Media/Movies
-    mkdir ~/ARM/Media/Music
-    mkdir ~/ARM/Media/Unidentified
+    sudo mkdir -p /mnt/media/ARM/raw
+    sudo mkdir -p /mnt/media/ARM/Media/Movies
+    sudo mkdir /mnt/media/ARM/Media/Music
+    sudo mkdir /mnt/media/ARM/Media/Unidentified
     sudo su
     cd /opt
     git clone https://github.com/RandomNinjaAtk/automatic-ripping-machine.git arm

--- a/README.md
+++ b/README.md
@@ -48,10 +48,7 @@ See: https://b3n.org/automatic-ripping-machine
     sudo apt install python3 python3-pip
     sudo apt-get install libdvd-pkg
     sudo dpkg-reconfigure libdvd-pkg
-    sudo mkdir -p /mnt/media/ARM/raw
-    sudo mkdir -p /mnt/media/ARM/Media/Movies
     sudo mkdir /mnt/media/ARM/Media/Music
-    sudo mkdir /mnt/media/ARM/Media/Unidentified
     sudo su
     cd /opt
     git clone https://github.com/RandomNinjaAtk/automatic-ripping-machine.git arm

--- a/README.md
+++ b/README.md
@@ -34,24 +34,24 @@ See: https://b3n.org/automatic-ripping-machine
 
 ## Install
 
-    sudo su
-    add-apt-repository ppa:heyarje/makemkv-beta
-    add-apt-repository ppa:stebbins/handbrake-releases
-    add-apt-repository ppa:mc3man/xerus-media
-    apt update
-    apt install makemkv-bin makemkv-oss
-    apt install handbrake-cli libavcodec-extra
-    apt install abcde flac imagemagick glyrc cdparanoia
-    apt install at
-    apt install python3 python3-pip
-    apt-get install libdvd-pkg
-    dpkg-reconfigure libdvd-pkg
+    sudo add-apt-repository ppa:heyarje/makemkv-beta
+    sudo add-apt-repository ppa:stebbins/handbrake-releases
+    sudo add-apt-repository ppa:mc3man/xerus-media
+    sudo apt update
+    sudo apt install makemkv-bin makemkv-oss
+    sudo apt install handbrake-cli libavcodec-extra
+    sudo apt install abcde flac imagemagick glyrc cdparanoia
+    sudo apt install at
+    sudo apt install python3 python3-pip
+    sudo apt-get install libdvd-pkg
+    sudo dpkg-reconfigure libdvd-pkg
     mkdir -p ~/ARM/raw
     mkdir -p ~/ARM/Media/Movies
     mkdir ~/ARM/Media/Music
     mkdir ~/ARM/Media/Unidentified
+    sudo su
     cd /opt
-    git clone https://github.com/ahnooie/automatic-ripping-machine.git arm
+    git clone https://github.com/RandomNinjaAtk/automatic-ripping-machine.git arm
     cd arm
     pip3 install -r requirements.txt
     ln -s /opt/arm/51-automedia.rules /lib/udev/rules.d/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ See: https://b3n.org/automatic-ripping-machine
 
 ## Install
 
+    sudo apt-get install git
+    sudo apt-get install regionset
+    sudo regionset /dev/sr0
     sudo add-apt-repository ppa:heyarje/makemkv-beta
     sudo add-apt-repository ppa:stebbins/handbrake-releases
     sudo add-apt-repository ppa:mc3man/xerus-media

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ See: https://b3n.org/automatic-ripping-machine
     sudo apt install python3 python3-pip
     sudo apt-get install libdvd-pkg
     sudo dpkg-reconfigure libdvd-pkg
-    sudo mkdir -p /mnt/media/ARM/Media/Music
     sudo su
     cd /opt
     git clone https://github.com/RandomNinjaAtk/automatic-ripping-machine.git arm

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See: https://b3n.org/automatic-ripping-machine
     sudo apt install python3 python3-pip
     sudo apt-get install libdvd-pkg
     sudo dpkg-reconfigure libdvd-pkg
-    sudo mkdir /mnt/media/ARM/Media/Music
+    sudo mkdir -p /mnt/media/ARM/Media/Music
     sudo su
     cd /opt
     git clone https://github.com/RandomNinjaAtk/automatic-ripping-machine.git arm

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ See: https://b3n.org/automatic-ripping-machine
     apt install python3 python3-pip
     apt-get install libdvd-pkg
     dpkg-reconfigure libdvd-pkg
+    mkdir -p ~/ARM/raw
+    mkdir -p ~/ARM/Media/Movies
+    mkdir ~/ARM/Media/Music
+    mkdir ~/ARM/Media/Unidentified
     cd /opt
     git clone https://github.com/ahnooie/automatic-ripping-machine.git arm
     cd arm

--- a/config.sample
+++ b/config.sample
@@ -54,11 +54,12 @@ MINLENGTH="600"
 # DVD's will always default back to the "mkv" mode. If this is set to "backup" then you must also set HandBrake's MAINFEATURE to true. 
 RIPMETHOD="mkv" 
 
+# MakeMKV Arguments
 # MakeMKV Profile used for controlling Audio Track Selection.
 # This is the default profile MakeMKV uses for Audio track selection. Updating this file or changing it is considered
 # to be advanced usage of MakeMKV. But this will allow users to alternatively tell makemkv to select HD audio tracks and etc.
-MAKEMKVPROFILE_FILE="/opt/arm/default.mmcp.xml"
-
+# MKV_ARGS="--profile=/opt/arm/default.mmcp.xml"
+MKV_ARGS=""
 
 ##########################
 ## HandBrake Parameters ##

--- a/config.sample
+++ b/config.sample
@@ -30,7 +30,7 @@ RAWPATH="/mnt/media/ARM/raw/"
 
 # Path to final media directory
 # Destination for final file.  Only used for movies that are positively identified
-MEDIA_DIR="/mnt/media/ARM/emby/movies/"
+MEDIA_DIR="/mnt/media/ARM/Media/Movies/"
 
 # Path to directory to hold log files
 # Make sure to include trailing /
@@ -81,6 +81,13 @@ HANDBRAKE_CLI=HandBrakeCLI
 # NOTE: For the most part, HandBrake correctly identifies the main feature on movie DVD's, although it is not perfect. 
 # However, it does not handle tv shows well at all.  You will likely want this value to be false when ripping tv shows.
 MAINFEATURE=false
+
+#####################
+## Enable Plex Use ##
+#####################
+
+# Set this setting to true, to enable Plex Extras support
+PLEX_SUPPORT=false
 
 #####################
 ## Emby Parameters ##

--- a/config.sample
+++ b/config.sample
@@ -22,15 +22,15 @@ SKIP_TRANSCODE=false
 
 # Base directory of ARM media directory
 # Ripped and transcoded files end up here
-ARMPATH="~/ARM/Media/Unidentified/"
+ARMPATH="/mnt/media/ARM/Media/Unidentified/"
 
 # Path to raw MakeMKV directory
 # Destination for MakeMKV and source for HandBrake
-RAWPATH="~/ARM/raw/"
+RAWPATH="/mnt/media/ARM/raw/"
 
 # Path to final media directory
 # Destination for final file.  Only used for movies that are positively identified
-MEDIA_DIR="~/ARM/Media/Movies/"
+MEDIA_DIR="/mnt/media/ARM/Media/Movies/"
 
 # Path to directory to hold log files
 # Make sure to include trailing /

--- a/config.sample
+++ b/config.sample
@@ -22,15 +22,15 @@ SKIP_TRANSCODE=false
 
 # Base directory of ARM media directory
 # Ripped and transcoded files end up here
-ARMPATH="/mnt/media/ARM/"
+ARMPATH="~/ARM/Media/Unidentified/"
 
 # Path to raw MakeMKV directory
 # Destination for MakeMKV and source for HandBrake
-RAWPATH="/mnt/media/ARM/raw/"
+RAWPATH="~/ARM/raw/"
 
 # Path to final media directory
 # Destination for final file.  Only used for movies that are positively identified
-MEDIA_DIR="/mnt/media/ARM/Media/Movies/"
+MEDIA_DIR="~/ARM/Media/Movies/"
 
 # Path to directory to hold log files
 # Make sure to include trailing /

--- a/config.sample
+++ b/config.sample
@@ -54,6 +54,12 @@ MINLENGTH="600"
 # DVD's will always default back to the "mkv" mode. If this is set to "backup" then you must also set HandBrake's MAINFEATURE to true. 
 RIPMETHOD="mkv" 
 
+# MakeMKV Profile used for controlling Audio Track Selection.
+# This is the default profile MakeMKV uses for Audio track selection. Updating this file or changing it is considered
+# to be advanced usage of MakeMKV. But this will allow users to alternatively tell makemkv to select HD audio tracks and etc.
+MAKEMKVPROFILE_FILE="/opt/arm/default.mmcp.xml"
+
+
 ##########################
 ## HandBrake Parameters ##
 ##########################

--- a/config.sample
+++ b/config.sample
@@ -43,9 +43,11 @@ LOGLIFE=1
 ##  File Permissions  ##
 ########################
 
-# Enabling this seting will set the file Permissions to "777", which is read/write/execute for all users
+# Enabling this seting will allow you to adjust the default file permissions of the outputted files
+# The default value is set to 777 for read/write/execute for all users, but can be changed below using the "CHMOD_VALUE" setting
 # This setting is helpfuly when storing the data locally on the system
 SET_MEDIA_PERMISSIONS=false
+CHMOD_VALUE=777
 
 ########################
 ## MakeMKV Parameters ##

--- a/config.sample
+++ b/config.sample
@@ -40,6 +40,14 @@ LOGPATH="/opt/arm/logs/"
 LOGLIFE=1
 
 ########################
+##  File Permissions  ##
+########################
+
+# Enabling this seting will set the file Permissions to "777", which is read/write/execute for all users
+# This setting is helpfuly when storing the data locally on the system
+SET_MEDIA_PERMISSIONS=false
+
+########################
 ## MakeMKV Parameters ##
 ########################
 

--- a/data_rip.sh
+++ b/data_rip.sh
@@ -20,6 +20,6 @@ source "$ARM_CONFIG"
 
 	eject
 	
-	chmod 777 -r "$DEST"
+	chmod 777 -R "$DEST"
 
 } >> "$LOG"

--- a/data_rip.sh
+++ b/data_rip.sh
@@ -7,8 +7,6 @@ source "$ARM_CONFIG"
 
 {
 
-
-
         TIMESTAMP=$(date '+%Y%m%d_%H%M%S');
         DEST="/mnt/media/ARM/Media/Data/${TIMESTAMP}_${ID_FS_LABEL}"
         mkdir -p "$DEST"
@@ -20,6 +18,12 @@ source "$ARM_CONFIG"
 
 	eject
 	
-	chmod 777 -R "$DEST"
+	if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
+			
+	chmod -R "$CHMOD_VALUE" "$DEST"
+			
+	else
+	
+	fi
 
 } >> "$LOG"

--- a/data_rip.sh
+++ b/data_rip.sh
@@ -21,9 +21,7 @@ source "$ARM_CONFIG"
 	if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
 			
 	chmod -R "$CHMOD_VALUE" "$DEST"
-			
-	else
-	
+		
 	fi
 
 } >> "$LOG"

--- a/data_rip.sh
+++ b/data_rip.sh
@@ -10,8 +10,8 @@ source "$ARM_CONFIG"
 
 
         TIMESTAMP=$(date '+%Y%m%d_%H%M%S');
-        DEST="/mnt/media/ARM/${TIMESTAMP}_${ID_FS_LABEL}"
-        mkdir "$DEST"
+        DEST="/mnt/media/ARM/Media/Data/${TIMESTAMP}_${ID_FS_LABEL}"
+        mkdir -p "$DEST"
 	FILENAME=${ID_FS_LABEL}_disc.iso
 
 
@@ -19,6 +19,7 @@ source "$ARM_CONFIG"
 	cat "$DEVNAME" > "$DEST/$FILENAME"
 
 	eject
-
+	
+	chmod 777 -r "$DEST"
 
 } >> "$LOG"

--- a/default.mmcp.xml
+++ b/default.mmcp.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<profile>
+    <!-- profile name - Default -->
+    <name lang="mogz">:5086</name>
+
+    <!-- Common MKV flags -->
+    <mkvSettings 
+        ignoreForcedSubtitlesFlag="true"
+        useISO639Type2T="false"
+        setFirstAudioTrackAsDefault="true"
+        setFirstSubtitleTrackAsDefault="true"
+        setFirstForcedSubtitleTrackAsDefault="true"
+        insertFirstChapter00IfMissing="true"
+    />
+
+    <!-- Settings overridable in preferences -->
+    <profileSettings
+        app_DefaultSelectionString="-sel:all,+sel:(favlang|nolang|single),-sel:(havemulti|havecore),-sel:mvcvideo,=100:all,-10:favlang"
+    />
+
+    <!-- Output formats currently supported by MakeMKV -->
+    <outputSettings name="copy" outputFormat="directCopy">
+        <description lang="eng">Copy track as is</description>
+        <description lang="ger">Track 1:1 kopieren</description>
+    </outputSettings>
+
+    <outputSettings name="lpcm" outputFormat="LPCM-raw">
+        <description lang="eng">Save as raw LPCM</description>
+        <description lang="ger">Als RAW LPCM speichern</description>
+    </outputSettings>
+
+    <outputSettings name="wavex" outputFormat="LPCM-wavex">
+        <description lang="eng">Save as LPCM in WAV container</description>
+        <description lang="ger">Als LPCM im WAV-Container speichern</description>
+    </outputSettings>
+
+    <outputSettings name="flac-best" outputFormat="FLAC">
+        <description lang="eng">Save as FLAC (best compression)</description>
+        <description lang="ger">Als FLAC speichern (höchste Komprimierungsstufe)</description>
+        <extraArgs>-compression_level 12</extraArgs>
+    </outputSettings>
+
+    <outputSettings name="flac-fast" outputFormat="FLAC">
+        <description lang="eng">Save as FLAC (fast compression)</description>
+        <extraArgs>-compression_level 5</extraArgs>
+    </outputSettings>
+
+    <!-- Default rule - copy as is -->
+    <trackSettings input="default">
+        <output outputSettingsName="copy" 
+                defaultSelection="$app_DefaultSelectionString">
+        </output>
+    </trackSettings>
+
+    <!-- Save LPCM mono or stereo as raw LPCM -->
+    <trackSettings input="LPCM-stereo">
+        <output outputSettingsName="lpcm"
+                defaultSelection="$app_DefaultSelectionString">
+        </output>
+    </trackSettings>
+
+    <!-- Put multi-channel LPCM into WAVEX container-->
+    <trackSettings input="LPCM-multi">
+        <output outputSettingsName="wavex"
+                defaultSelection="$app_DefaultSelectionString">
+        </output>
+    </trackSettings>
+
+</profile>

--- a/video_rip.sh
+++ b/video_rip.sh
@@ -15,6 +15,7 @@ VIDEO_TYPE=$3
  	echo "Ripping video ${ID_FS_LABEL} from ${DEVNAME}" >> "$LOG"
 	TIMESTAMP=$(date '+%Y%m%d_%H%M%S');
 	DEST="${RAWPATH}/${VIDEO_TITLE}_${TIMESTAMP}"
+	PROFILE="--profile=/${MAKEMKVPROFILE_FILE}"
 	RIPSTART=$(date +%s);
     
 	mkdir "$DEST"
@@ -24,7 +25,7 @@ VIDEO_TYPE=$3
 		echo "Using backup method of ripping." >> "$LOG"
 		DISC="${DEVNAME: -1}"
 		echo "Sending command: makemkvcon backup --decrypt -r disc:$DISC $DEST"
-		makemkvcon backup --decrypt -r disc:"$DISC" "$DEST"/
+		makemkvcon "$PROFILE" backup --decrypt -r disc:"$DISC" "$DEST"/
 		eject "$DEVNAME"
 	elif [ "$MAINFEATURE" = true ] && [ "$ID_CDROM_MEDIA_DVD" = "1" ] && [ -z "$ID_CDROM_MEDIA_BD" ]; then
 		echo "Media is DVD and Main Feature parameter in config file is true.  Bypassing MakeMKV." >> "$LOG"
@@ -33,7 +34,7 @@ VIDEO_TYPE=$3
 	echo "DEST is ${DEST}"
 	else
 		echo "Using mkv method of ripping." >> "$LOG"
-		makemkvcon mkv dev:"$DEVNAME" all "$DEST" --minlength="$MINLENGTH" -r
+		makemkvcon "$PROFILE" mkv dev:"$DEVNAME" all "$DEST" --minlength="$MINLENGTH" -r
 		eject "$DEVNAME"
 	fi
 

--- a/video_rip.sh
+++ b/video_rip.sh
@@ -17,7 +17,7 @@ VIDEO_TYPE=$3
 	DEST="${RAWPATH}/${VIDEO_TITLE}_${TIMESTAMP}"
 	RIPSTART=$(date +%s);
     
-	mkdir "$DEST"
+	mkdir -p "$DEST"
 
 	#echo /opt/arm/video_transcode.sh \"$DEST\" \"$VIDEO_TITLE\" $TIMESTAMP >> $LOG
 	if [ "$RIPMETHOD" = "backup" ] && [ "$ID_CDROM_MEDIA_BD" = "1" ]; then

--- a/video_rip.sh
+++ b/video_rip.sh
@@ -15,7 +15,7 @@ VIDEO_TYPE=$3
  	echo "Ripping video ${ID_FS_LABEL} from ${DEVNAME}" >> "$LOG"
 	TIMESTAMP=$(date '+%Y%m%d_%H%M%S');
 	DEST="${RAWPATH}/${VIDEO_TITLE}_${TIMESTAMP}"
-	PROFILE="--profile=/${MAKEMKVPROFILE_FILE}"
+	PROFILE="--profile=${MAKEMKVPROFILE_FILE}"
 	RIPSTART=$(date +%s);
     
 	mkdir "$DEST"

--- a/video_rip.sh
+++ b/video_rip.sh
@@ -15,7 +15,6 @@ VIDEO_TYPE=$3
  	echo "Ripping video ${ID_FS_LABEL} from ${DEVNAME}" >> "$LOG"
 	TIMESTAMP=$(date '+%Y%m%d_%H%M%S');
 	DEST="${RAWPATH}/${VIDEO_TITLE}_${TIMESTAMP}"
-	PROFILE="--profile=${MAKEMKVPROFILE_FILE}"
 	RIPSTART=$(date +%s);
     
 	mkdir "$DEST"
@@ -25,7 +24,7 @@ VIDEO_TYPE=$3
 		echo "Using backup method of ripping." >> "$LOG"
 		DISC="${DEVNAME: -1}"
 		echo "Sending command: makemkvcon backup --decrypt -r disc:$DISC $DEST"
-		makemkvcon "$PROFILE" backup --decrypt -r disc:"$DISC" "$DEST"/
+		makemkvcon "$MKV_ARGS" backup --decrypt -r disc:"$DISC" "$DEST"/
 		eject "$DEVNAME"
 	elif [ "$MAINFEATURE" = true ] && [ "$ID_CDROM_MEDIA_DVD" = "1" ] && [ -z "$ID_CDROM_MEDIA_BD" ]; then
 		echo "Media is DVD and Main Feature parameter in config file is true.  Bypassing MakeMKV." >> "$LOG"
@@ -34,7 +33,7 @@ VIDEO_TYPE=$3
 	echo "DEST is ${DEST}"
 	else
 		echo "Using mkv method of ripping." >> "$LOG"
-		makemkvcon "$PROFILE" mkv dev:"$DEVNAME" all "$DEST" --minlength="$MINLENGTH" -r
+		makemkvcon "$MKV_ARGS" mkv dev:"$DEVNAME" all "$DEST" --minlength="$MINLENGTH" -r
 		eject "$DEVNAME"
 	fi
 

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -182,7 +182,7 @@ TIMESTAMP=$5
        			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/Featurettes/" >> "$LOG"
 			
 			# Move Largest file to main folder for Plex/Emby/Kodi to detect main movie
-			ls -S "$MEDIA_DIR/$LABEL/extras/" | head -1 | xargs -I '{}' mv {} "$MEDIA_DIR/$LABEL/" >> "$LOG"
+			ls -S "$MEDIA_DIR/$LABEL/Featurettes/" | head -1 | xargs -I '{}' mv {} "$MEDIA_DIR/$LABEL/" >> "$LOG"
 			
 		else
 				

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -182,7 +182,7 @@ TIMESTAMP=$5
        			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/Featurettes/" >> "$LOG"
 			
 			# Move Largest file to main folder for Plex/Emby/Kodi to detect main movie
-			ls -S "$MEDIA_DIR/$LABEL/Featurettes/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/Featurettes/"{} "$MEDIA_DIR/$LABEL/" >> "$LOG"
+			ls -S "$MEDIA_DIR/$LABEL/Featurettes/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/Featurettes/"{} "$MEDIA_DIR/$LABEL/$LABEL.mkv" >> "$LOG"
 			
 		else
 				
@@ -197,7 +197,7 @@ TIMESTAMP=$5
        			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/extras/" >> "$LOG"
 			
 			# Move Largest file to main folder for Plex/Emby/Kodi to detect main movie
-			ls -S "$MEDIA_DIR/$LABEL/extras/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/extras/"{} "$MEDIA_DIR/$LABEL/" >> "$LOG"
+			ls -S "$MEDIA_DIR/$LABEL/extras/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/extras/"{} "$MEDIA_DIR/$LABEL/$LABEL.mkv" >> "$LOG"
 			
 			if [ "$EMBY_REFRESH" = true ]; then
 				# signal emby to scan library

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -120,9 +120,7 @@ TIMESTAMP=$5
 			if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
 			
 			chmod -R "$CHMOD_VALUE" "$MEDIA_DIR"
-			
-			else
-			
+							
 			fi
 
 			if [ "$EMBY_REFRESH" = true ]; then
@@ -146,9 +144,7 @@ TIMESTAMP=$5
 			if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
 			
 			chmod -R "$CHMOD_VALUE" "$MEDIA_DIR/$LABEL"
-			
-			else
-			
+						
 			fi
 
 			if [ "$EMBY_REFRESH" = true ]; then
@@ -195,9 +191,7 @@ TIMESTAMP=$5
 			if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
 			
 			chmod -R "$CHMOD_VALUE" "$MEDIA_DIR/$LABEL"
-			
-			else
-			
+						
 			fi
 			
 		fi
@@ -222,9 +216,7 @@ TIMESTAMP=$5
 			if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
 			
 			chmod -R "$CHMOD_VALUE" "$MEDIA_DIR/$LABEL"
-			
-			else
-			
+						
 			fi
 		else
 				
@@ -245,9 +237,7 @@ TIMESTAMP=$5
 			if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
 			
 			chmod -R "$CHMOD_VALUE" "$MEDIA_DIR/$LABEL"
-			
-			else
-			
+						
 			fi
 			
 			if [ "$EMBY_REFRESH" = true ]; then

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -169,16 +169,37 @@ TIMESTAMP=$5
 		fi
 
 		#now move "extras"
-		# shellcheck disable=SC2129,SC2016
-		mkdir -v "$MEDIA_DIR/$LABEL/extras" >> "$LOG"
-		# shellcheck disable=SC2086
-        echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/extras/\""" >> "$LOG"
-        mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/extras/" >> "$LOG"
-		if [ "$EMBY_REFRESH" = true ]; then
-			# signal emby to scan library
-			embyrefresh
+		if [ "$PLEX_SUPPORT" = true ]; then
+		
+			# shellcheck disable=SC2129,SC2016
+			mkdir -v "$MEDIA_DIR/$LABEL/Featurettes" >> "$LOG"
+			
+			# Create Emby ignore file for "extras" Folder
+			touch "$MEDIA_DIR/$LABEL/Featurettes/.ignore"
+			
+			# shellcheck disable=SC2086
+       			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/Featurettes/\""" >> "$LOG"
+       			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/Featurettes/" >> "$LOG"
+				
 		else
-			echo "Emby Refresh False.  Skipping library scan" >> "$LOG"
+				
+			# shellcheck disable=SC2129,SC2016
+			mkdir -v "$MEDIA_DIR/$LABEL/extras" >> "$LOG"
+				
+			# Create Plex ignore file for "extras" Folder
+			touch "$MEDIA_DIR/$LABEL/extras/.plexignore"
+			
+			# shellcheck disable=SC2086
+      			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/extras/\""" >> "$LOG"
+       			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/extras/" >> "$LOG"
+			
+			if [ "$EMBY_REFRESH" = true ]; then
+				# signal emby to scan library
+					embyrefresh
+			else
+					echo "Emby Refresh False.  Skipping library scan" >> "$LOG"
+			fi
+				
 		fi
 		rmdir "$DEST"
 	fi

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -29,7 +29,7 @@ TIMESTAMP=$5
 	fi	
 
 	# DEST="${ARMPATH}/${LABEL}_${TIMESTAMP}"
-	mkdir "$DEST"
+	mkdir -p "$DEST"
 	if [ "$SKIP_TRANSCODE" = true ] && [ "$RIPMETHOD" = "mkv" ]; then
 		# this only works for files ripped by MakeMKV into .mkv files
 		echo "Skipping transcode.  Moving files from $SRC to $DEST" >> "$LOG"
@@ -132,7 +132,7 @@ TIMESTAMP=$5
 		# shellcheck disable=SC2129,SC2016
 		echo '$VIDEO_TYPE is movie, $MAINFEATURE is true, $HAS_NICE_TITLE is true, $EMBY_SUBFOLDERS is true' >> "$LOG"
         echo "Moving a single file to emby subfolders" >> "$LOG"
-		mkdir "$MEDIA_DIR/$LABEL" >> "$LOG"
+		mkdir -p "$MEDIA_DIR/$LABEL" >> "$LOG"
 		if [ ! -f "$MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT" ]; then
 			echo "No file found.  Moving \"$DEST/$LABEL.$DEST_EXT to $MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT\"" >> "$LOG"
 			mv -n "$DEST/$LABEL.$DEST_EXT" "$MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT"
@@ -169,7 +169,7 @@ TIMESTAMP=$5
 		echo '$VIDEO_TYPE is movie, $MAINFEATURE is false, $HAS_NICE_TITLE is true, $EMBY_SUBFOLDERS is true' >> "$LOG"
         echo "Moving multiple files to emby movie subfolders" >> "$LOG"
 		echo "First move main title" >> "$LOG"
-        mkdir -v "$MEDIA_DIR/$LABEL" >> "$LOG"
+        mkdir -p -v "$MEDIA_DIR/$LABEL" >> "$LOG"
 		if [ ! -f "$MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT" ]; then
 			echo "No file found.  Moving \"$DEST/$LABEL.$DEST_EXT to $MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT\"" >> "$LOG"
 			mv -n "$DEST/$LABEL.$DEST_EXT" "$MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT" >> "$LOG"
@@ -180,7 +180,7 @@ TIMESTAMP=$5
 		if [ "$PLEX_SUPPORT" = true ]; then
 		
 			# shellcheck disable=SC2129,SC2016
-			mkdir -v "$MEDIA_DIR/$LABEL/Featurettes" >> "$LOG"
+			mkdir -p -v "$MEDIA_DIR/$LABEL/Featurettes" >> "$LOG"
 			
 			# Create Emby ignore file for "extras" Folder
 			touch "$MEDIA_DIR/$LABEL/Featurettes/.ignore"  >> "$LOG"
@@ -197,7 +197,7 @@ TIMESTAMP=$5
 		else
 				
 			# shellcheck disable=SC2129,SC2016
-			mkdir -v "$MEDIA_DIR/$LABEL/extras" >> "$LOG"
+			mkdir -p -v "$MEDIA_DIR/$LABEL/extras" >> "$LOG"
 				
 			# Create Plex ignore file for "extras" Folder
 			touch "$MEDIA_DIR/$LABEL/extras/.plexignore"  >> "$LOG"

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -116,6 +116,8 @@ TIMESTAMP=$5
 		if [ ! -f "$MEDIA_DIR/$LABEL.$DEST_EXT" ]; then
 			echo "No file found.  Moving \"$DEST/$LABEL.$DEST_EXT to $MEDIA_DIR/$LABEL.$DEST_EXT\"" >> "$LOG"
 			mv -n "$DEST/$LABEL.$DEST_EXT" "$MEDIA_DIR/$LABEL.$DEST_EXT"
+			
+			chmod 777 "$MEDIA_DIR" -R
 
 			if [ "$EMBY_REFRESH" = true ]; then
 				# signal emby to scan library
@@ -134,6 +136,8 @@ TIMESTAMP=$5
 		if [ ! -f "$MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT" ]; then
 			echo "No file found.  Moving \"$DEST/$LABEL.$DEST_EXT to $MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT\"" >> "$LOG"
 			mv -n "$DEST/$LABEL.$DEST_EXT" "$MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT"
+			
+			chmod 777 "$MEDIA_DIR/$LABEL" -R
 
 			if [ "$EMBY_REFRESH" = true ]; then
 				# signal emby to scan library
@@ -151,6 +155,9 @@ TIMESTAMP=$5
 		echo "***WARNING!*** This will likely leave files in the transcoding directory as there is very likely existing files in the media directory"
         echo "Moving multiple files to emby movie folder" >> "$LOG"
 		mv -n "$DEST/$LABEL.$DEST_EXT" "$MEDIA_DIR/$LABEL.$DEST_EXT"
+		
+		chmod 777 "$MEDIA_DIR" -R
+		
 		if [ "$EMBY_REFRESH" = true ]; then
 			# signal emby to scan library
 			embyrefresh
@@ -166,6 +173,7 @@ TIMESTAMP=$5
 		if [ ! -f "$MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT" ]; then
 			echo "No file found.  Moving \"$DEST/$LABEL.$DEST_EXT to $MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT\"" >> "$LOG"
 			mv -n "$DEST/$LABEL.$DEST_EXT" "$MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT" >> "$LOG"
+			chmod 777 "$MEDIA_DIR/$LABEL" -R
 		fi
 
 		#now move "extras"
@@ -185,6 +193,7 @@ TIMESTAMP=$5
 			# shellcheck disable=SC2012
 			ls -S "$MEDIA_DIR/$LABEL/Featurettes/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/Featurettes/"{} "$MEDIA_DIR/$LABEL/$LABEL.mkv" >> "$LOG"
 			
+			chmod 777 "$MEDIA_DIR/$LABEL" -R
 		else
 				
 			# shellcheck disable=SC2129,SC2016
@@ -200,6 +209,8 @@ TIMESTAMP=$5
 			# Move Largest file to main folder for Plex/Emby/Kodi to detect main movie
 			# shellcheck disable=SC2012
 			ls -S "$MEDIA_DIR/$LABEL/extras/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/extras/"{} "$MEDIA_DIR/$LABEL/$LABEL.mkv" >> "$LOG"
+			
+			chmod 777 "$MEDIA_DIR/$LABEL" -R
 			
 			if [ "$EMBY_REFRESH" = true ]; then
 				# signal emby to scan library

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -182,7 +182,7 @@ TIMESTAMP=$5
        			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/Featurettes/" >> "$LOG"
 			
 			# Move Largest file to main folder for Plex/Emby/Kodi to detect main movie
-			ls -S "$MEDIA_DIR/$LABEL/Featurettes/" | head -1 | xargs -I '{}' mv {} "$MEDIA_DIR/$LABEL/" >> "$LOG"
+			ls -S "$MEDIA_DIR/$LABEL/Featurettes/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/Featurettes/"{} "$MEDIA_DIR/$LABEL/" >> "$LOG"
 			
 		else
 				
@@ -197,7 +197,7 @@ TIMESTAMP=$5
        			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/extras/" >> "$LOG"
 			
 			# Move Largest file to main folder for Plex/Emby/Kodi to detect main movie
-			ls -S "$MEDIA_DIR/$LABEL/extras/" | head -1 | xargs -I '{}' mv {} "$MEDIA_DIR/$LABEL/" >> "$LOG"
+			ls -S "$MEDIA_DIR/$LABEL/extras/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/extras/"{} "$MEDIA_DIR/$LABEL/" >> "$LOG"
 			
 			if [ "$EMBY_REFRESH" = true ]; then
 				# signal emby to scan library

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -175,7 +175,7 @@ TIMESTAMP=$5
 			mkdir -v "$MEDIA_DIR/$LABEL/Featurettes" >> "$LOG"
 			
 			# Create Emby ignore file for "extras" Folder
-			touch "$MEDIA_DIR/$LABEL/Featurettes/.ignore"
+			touch "$MEDIA_DIR/$LABEL/Featurettes/.ignore"  >> "$LOG"
 			
 			# shellcheck disable=SC2086
        			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/Featurettes/\""" >> "$LOG"
@@ -187,7 +187,7 @@ TIMESTAMP=$5
 			mkdir -v "$MEDIA_DIR/$LABEL/extras" >> "$LOG"
 				
 			# Create Plex ignore file for "extras" Folder
-			touch "$MEDIA_DIR/$LABEL/extras/.plexignore"
+			touch "$MEDIA_DIR/$LABEL/extras/.plexignore"  >> "$LOG"
 			
 			# shellcheck disable=SC2086
       			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/extras/\""" >> "$LOG"

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -182,6 +182,7 @@ TIMESTAMP=$5
        			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/Featurettes/" >> "$LOG"
 			
 			# Move Largest file to main folder for Plex/Emby/Kodi to detect main movie
+			# shellcheck disable=SC2012
 			ls -S "$MEDIA_DIR/$LABEL/Featurettes/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/Featurettes/"{} "$MEDIA_DIR/$LABEL/$LABEL.mkv" >> "$LOG"
 			
 		else
@@ -197,6 +198,7 @@ TIMESTAMP=$5
        			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/extras/" >> "$LOG"
 			
 			# Move Largest file to main folder for Plex/Emby/Kodi to detect main movie
+			# shellcheck disable=SC2012
 			ls -S "$MEDIA_DIR/$LABEL/extras/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/extras/"{} "$MEDIA_DIR/$LABEL/$LABEL.mkv" >> "$LOG"
 			
 			if [ "$EMBY_REFRESH" = true ]; then

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -117,7 +117,13 @@ TIMESTAMP=$5
 			echo "No file found.  Moving \"$DEST/$LABEL.$DEST_EXT to $MEDIA_DIR/$LABEL.$DEST_EXT\"" >> "$LOG"
 			mv -n "$DEST/$LABEL.$DEST_EXT" "$MEDIA_DIR/$LABEL.$DEST_EXT"
 			
-			chmod 777 "$MEDIA_DIR" -R
+			if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
+			
+			chmod -R "$CHMOD_VALUE" "$MEDIA_DIR"
+			
+			else
+			
+			fi
 
 			if [ "$EMBY_REFRESH" = true ]; then
 				# signal emby to scan library
@@ -137,7 +143,13 @@ TIMESTAMP=$5
 			echo "No file found.  Moving \"$DEST/$LABEL.$DEST_EXT to $MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT\"" >> "$LOG"
 			mv -n "$DEST/$LABEL.$DEST_EXT" "$MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT"
 			
-			chmod 777 "$MEDIA_DIR/$LABEL" -R
+			if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
+			
+			chmod -R "$CHMOD_VALUE" "$MEDIA_DIR/$LABEL"
+			
+			else
+			
+			fi
 
 			if [ "$EMBY_REFRESH" = true ]; then
 				# signal emby to scan library
@@ -156,7 +168,13 @@ TIMESTAMP=$5
         echo "Moving multiple files to emby movie folder" >> "$LOG"
 		mv -n "$DEST/$LABEL.$DEST_EXT" "$MEDIA_DIR/$LABEL.$DEST_EXT"
 		
-		chmod 777 "$MEDIA_DIR" -R
+		if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
+			
+		chmod -R "$CHMOD_VALUE" "$MEDIA_DIR"
+			
+		else
+			
+		fi
 		
 		if [ "$EMBY_REFRESH" = true ]; then
 			# signal emby to scan library
@@ -173,7 +191,15 @@ TIMESTAMP=$5
 		if [ ! -f "$MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT" ]; then
 			echo "No file found.  Moving \"$DEST/$LABEL.$DEST_EXT to $MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT\"" >> "$LOG"
 			mv -n "$DEST/$LABEL.$DEST_EXT" "$MEDIA_DIR/$LABEL/$LABEL.$DEST_EXT" >> "$LOG"
-			chmod 777 "$MEDIA_DIR/$LABEL" -R
+			
+			if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
+			
+			chmod -R "$CHMOD_VALUE" "$MEDIA_DIR/$LABEL"
+			
+			else
+			
+			fi
+			
 		fi
 
 		#now move "extras"
@@ -193,7 +219,13 @@ TIMESTAMP=$5
 			# shellcheck disable=SC2012
 			ls -S "$MEDIA_DIR/$LABEL/Featurettes/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/Featurettes/"{} "$MEDIA_DIR/$LABEL/$LABEL.mkv" >> "$LOG"
 			
-			chmod 777 "$MEDIA_DIR/$LABEL" -R
+			if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
+			
+			chmod -R "$CHMOD_VALUE" "$MEDIA_DIR/$LABEL"
+			
+			else
+			
+			fi
 		else
 				
 			# shellcheck disable=SC2129,SC2016
@@ -210,7 +242,13 @@ TIMESTAMP=$5
 			# shellcheck disable=SC2012
 			ls -S "$MEDIA_DIR/$LABEL/extras/" | head -1 | xargs -I '{}' mv "$MEDIA_DIR/$LABEL/extras/"{} "$MEDIA_DIR/$LABEL/$LABEL.mkv" >> "$LOG"
 			
-			chmod 777 "$MEDIA_DIR/$LABEL" -R
+			if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
+			
+			chmod -R "$CHMOD_VALUE" "$MEDIA_DIR/$LABEL"
+			
+			else
+			
+			fi
 			
 			if [ "$EMBY_REFRESH" = true ]; then
 				# signal emby to scan library

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -180,7 +180,10 @@ TIMESTAMP=$5
 			# shellcheck disable=SC2086
        			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/Featurettes/\""" >> "$LOG"
        			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/Featurettes/" >> "$LOG"
-				
+			
+			# Move Largest file to main folder for Plex/Emby/Kodi to detect main movie
+			ls -S "$MEDIA_DIR/$LABEL/extras/" | head -1 | xargs -I '{}' mv {} "$MEDIA_DIR/$LABEL/" >> "$LOG"
+			
 		else
 				
 			# shellcheck disable=SC2129,SC2016
@@ -192,6 +195,9 @@ TIMESTAMP=$5
 			# shellcheck disable=SC2086
       			echo "Sending command: mv -n "\"$DEST/$LABEL/*\"" "\"$MEDIA_DIR/$LABEL/extras/\""" >> "$LOG"
        			mv -n "${DEST}"/* "$MEDIA_DIR/$LABEL/extras/" >> "$LOG"
+			
+			# Move Largest file to main folder for Plex/Emby/Kodi to detect main movie
+			ls -S "$MEDIA_DIR/$LABEL/extras/" | head -1 | xargs -I '{}' mv {} "$MEDIA_DIR/$LABEL/" >> "$LOG"
 			
 			if [ "$EMBY_REFRESH" = true ]; then
 				# signal emby to scan library

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -167,9 +167,7 @@ TIMESTAMP=$5
 		if [ "$SET_MEDIA_PERMISSIONS" = true ]; then
 			
 		chmod -R "$CHMOD_VALUE" "$MEDIA_DIR"
-			
-		else
-			
+					
 		fi
 		
 		if [ "$EMBY_REFRESH" = true ]; then


### PR DESCRIPTION
So this is my combined merge, I have tested this myself. It adds support for Plex, MakeMKV profiles and Main Movie. The beauty of this is that it also enhances Emby, to allow users to run both Plex and Emby using the same set of files.

This change will also enable the ARM to guess at which file is the main movie. When moving the files to the Extras/Featurettes sub-folders, the script will now access those files, select the largest file in terms of file size and move it the root of the movie folder. That way when Plex or Emby scans the directories, the movie can be automatically added as it is supposed too!

If you have any questions, let me know. I'm ripping straight to MKV with no transcode, these changes only mainly effect if your not transcoding. If you are transcoding, the MakeMKV Profile will still work. 