### PR TITLE
Add HDDVD support to identify.sh

### DIFF
--- a/identify.sh
+++ b/identify.sh
@@ -46,6 +46,7 @@ if [ "$ID_FS_TYPE" == "udf" ]; then
 		# check to see if this is really a video
 		mkdir -p /mnt/"$DEVNAME"
 		mount "$DEVNAME" /mnt/"$DEVNAME"
+		# shellcheck disable=SC2126
 		if [[ -d /mnt/${DEVNAME}/VIDEO_TS || -d /mnt/${DEVNAME}/BDMV || -d /mnt/${DEVNAME}/HVDVD_TS || $(ls -laR /mnt/${DEVNAME}/ 2>/dev/null |grep -P "HVDVD_TS" |wc -l) == 1 ]]; then
 			echo "identified udf as video" >> "$LOG"
 

--- a/identify.sh
+++ b/identify.sh
@@ -46,6 +46,7 @@ if [ "$ID_FS_TYPE" == "udf" ]; then
 		# check to see if this is really a video
 		mkdir -p /mnt/"$DEVNAME"
 		mount "$DEVNAME" /mnt/"$DEVNAME"
+		# shellcheck disable=SC2010
 		# shellcheck disable=SC2126
 		if [[ -d /mnt/${DEVNAME}/VIDEO_TS || -d /mnt/${DEVNAME}/BDMV || -d /mnt/${DEVNAME}/HVDVD_TS || $(ls -laR /mnt/${DEVNAME}/ 2>/dev/null |grep -P "HVDVD_TS" |wc -l) == 1 ]]; then
 			echo "identified udf as video" >> "$LOG"

--- a/identify.sh
+++ b/identify.sh
@@ -46,7 +46,7 @@ if [ "$ID_FS_TYPE" == "udf" ]; then
 		# check to see if this is really a video
 		mkdir -p /mnt/"$DEVNAME"
 		mount "$DEVNAME" /mnt/"$DEVNAME"
-		if [[ -d /mnt/${DEVNAME}/VIDEO_TS || -d /mnt/${DEVNAME}/BDMV ]]; then
+		if [[ -d /mnt/${DEVNAME}/VIDEO_TS || -d /mnt/${DEVNAME}/BDMV || -d /mnt/${DEVNAME}/HVDVD_TS || $(ls -laR /mnt/${DEVNAME}/ 2>/dev/null |grep -P "HVDVD_TS" |wc -l) == 1 ]]; then
 			echo "identified udf as video" >> "$LOG"
 
 			if [ "$GET_VIDEO_TITLE" == true ]; then

--- a/identify.sh
+++ b/identify.sh
@@ -46,6 +46,7 @@ if [ "$ID_FS_TYPE" == "udf" ]; then
 		# check to see if this is really a video
 		mkdir -p /mnt/"$DEVNAME"
 		mount "$DEVNAME" /mnt/"$DEVNAME"
+		# shellcheck disable=SC2086
 		# shellcheck disable=SC2010
 		# shellcheck disable=SC2126
 		if [[ -d /mnt/${DEVNAME}/VIDEO_TS || -d /mnt/${DEVNAME}/BDMV || -d /mnt/${DEVNAME}/HVDVD_TS || $(ls -laR /mnt/${DEVNAME}/ 2>/dev/null |grep -P "HVDVD_TS" |wc -l) == 1 ]]; then


### PR DESCRIPTION
This has worked 3/3 at this point for me with HDDVDs.

I found in some cases the file system of the HDDVD is read-only and the standard -d check won't work on the HVDVD_TS directory which is why sometimes the ugly 'ls' command is required.

Resolves issue #59 