### PR TITLE
Feature audio cd identify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ archive/
 config
 temp/
 test.py
+*.sh~

--- a/config.sample
+++ b/config.sample
@@ -162,10 +162,15 @@ PO_APP_KEY=""
 # use the label of the DVD/CD or else use empty.log
 # this is required for udev events where there is no media available
 # such as ejecting the drive
-if [ -z "$ID_FS_LABEL" ]; then
-        LOGFILE="empty.log"
-else
+
+if [ -n "$ID_FS_LABEL" ]; then
         LOGFILE=${ID_FS_LABEL}".log"
+        elif [[ -n "$ID_CDROM_MEDIA_TRACK_COUNT_AUDIO" && $(which abcde-musicbrainz-tool) ]]; then
+                LOGFILE=$(abcde-musicbrainz-tool --device "$DEVNAME" | cut -f1 -d ' ')".log"
+        elif [[ -n "$ID_CDROM_MEDIA_TRACK_COUNT_AUDIO" &&  $(which cd-discid) ]]; then
+                LOGFILE=$(cd-discid "$DEVNAME" | cut -f1 -d ' ')".log"
+else
+        LOGFILE="empty.log"
 fi
 
 # Set full logfile path


### PR DESCRIPTION
Enhance the logging methodology for audio discs. If an audio disc is identified, the musicbrainz or cddb disc ID is used as a logging file name. 

This makes multiple rip processes easier to identify and troubleshoot, and puts audio ripping logs in position to be cleaned by the existing log-cleaning routine.