### PR TITLE
Avoid eject loop

### DIFF
--- a/identify.sh
+++ b/identify.sh
@@ -114,6 +114,8 @@ elif [ "$ID_FS_TYPE" == "iso9660" ]; then
 	echo "identified data" >> "$LOG"
 	/opt/arm/data_rip.sh "$LOG"
 	eject "$DEVNAME"
+elif [ -z "${ID_CDROM_MEDIA+x}" ] && [ -z "${ID_FS_TYPE}" ]; then
+	echo "drive seems empty, not ejecting" >> "$LOG"
 else
 	echo "unable to identify"
 	echo "$ID_CDROM_MEDIA_TRACK_COUNT_AUDIO" >> "$LOG"


### PR DESCRIPTION
There was a problem with VirtualBox on Mac that caused the eject of a disk to
trigger the udev rule and script again. So it ejected, even though the drive was
empty, triggering the udev rule and script again...
I don't know why it appeared for me and not for anyone else, but I added an extra case in identify.sh to skip the eject in there doesn't seem to be a disk in the drive.