### PR TITLE
Change LABEL variable in LOG and Notify message at transcode completion.

### DIFF
--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -295,8 +295,8 @@ TRANSEND=$(date +%s);
 TRANSSEC=$((TRANSEND-TRANSSTART));
 TRANSTIME="$((TRANSSEC / 3600)) hours, $(((TRANSSEC / 60) % 60)) minutes and $((TRANSSEC % 60)) seconds."
 
-echo "STAT: ${ID_FS_LABEL} transcoded in ${TRANSTIME}" >> "$LOG"
+echo "STAT: ${LABEL} transcoded in ${TRANSTIME}" >> "$LOG"
 
 #echo /opt/arm/rename.sh $DEST
 
-echo /opt/arm/notify.sh "\"Transcode: ${ID_FS_LABEL} completed in ${TRANSTIME}\"" |at now
+echo /opt/arm/notify.sh "\"Transcode: ${LABEL} completed in ${TRANSTIME}\"" |at now


### PR DESCRIPTION
Fixes #85 

ID_FS_LABEL is sometimes blank and not used anywhere else in this script, but the LABEL variable is used extensively in this script and will always have a value that matches the directory of the transcoded files.

This has brought my Transcode notification naming consistency to 100% from much lower as shown in these photos.

![img_006968144ed9-1](https://user-images.githubusercontent.com/17124213/30544882-ee51d686-9c55-11e7-8ec9-a3418c7d78d8.jpeg)

![img_638f969616e8-1](https://user-images.githubusercontent.com/17124213/30544981-4b05d882-9c56-11e7-90f5-1afd3009d604.jpeg)
