### PR TITLE
Move logging logic out of config file

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -39,6 +39,9 @@ LOGPATH="/opt/arm/logs/"
 # How long to let log files live before deleting (in days)
 LOGLIFE=1
 
+# Set to true if you prefer a single log file for all activity versus a separate log per disc.
+LOG_SINGLE_FILE=false 
+
 ########################
 ##  File Permissions  ##
 ########################

--- a/config.sample
+++ b/config.sample
@@ -175,21 +175,5 @@ PO_APP_KEY=""
 OMDB_API_KEY=""
 
 
-# Determine logfile name
-# use the label of the DVD/CD or else use empty.log
-# this is required for udev events where there is no media available
-# such as ejecting the drive
 
-if [ -n "$ID_FS_LABEL" ]; then
-        LOGFILE=${ID_FS_LABEL}".log"
-        elif [[ -n "$ID_CDROM_MEDIA_TRACK_COUNT_AUDIO" && $(which abcde-musicbrainz-tool) ]]; then
-                LOGFILE=$(abcde-musicbrainz-tool --device "$DEVNAME" | cut -f1 -d ' ')".log"
-        elif [[ -n "$ID_CDROM_MEDIA_TRACK_COUNT_AUDIO" &&  $(which cd-discid) ]]; then
-                LOGFILE=$(cd-discid "$DEVNAME" | cut -f1 -d ' ')".log"
-else
-        LOGFILE="empty.log"
-fi
-
-# Set full logfile path
-LOG=$LOGPATH$LOGFILE
 

--- a/data_rip.sh
+++ b/data_rip.sh
@@ -7,6 +7,8 @@ source "$ARM_CONFIG"
 # shellcheck disable=SC1090
 source "$DISC_INFO"
 
+LOG=$1
+
 {
 
         TIMESTAMP=$(date '+%Y%m%d_%H%M%S');
@@ -33,7 +35,7 @@ source "$DISC_INFO"
 	fi
 
 	if [ "$NOTIFY_RIP" = "true" ]; then
-		echo /opt/arm/notify.sh "\"Ripped: ${FILENAME} completed from ${DEVNAME}\"" |at -M now
+		echo /opt/arm/notify.sh "\"Ripped: ${FILENAME} completed from ${DEVNAME}\" \"$LOG\""|at -M now
     fi
 
 } >> "$LOG"

--- a/identify.sh
+++ b/identify.sh
@@ -121,7 +121,7 @@ if [ "$ID_FS_TYPE" == "udf" ]; then
 		else
 			umount "/mnt/$DEVNAME"
 			echo "identified udf as data" >> "$LOG"
-			/opt/arm/data_rip.sh
+			/opt/arm/data_rip.sh "$LOG"
 			eject "$DEVNAME"
 
 		fi

--- a/identify.sh
+++ b/identify.sh
@@ -12,18 +12,23 @@ source "$ARM_CONFIG"
 source "$DISC_INFO"
 
 # Determine logfile name
-# use the label of the DVD/CD or else use empty.log
+# If LOG_SINGLE_FILE is set to true, log all activity to ARM.log
+# If false (default) use the label of the DVD/CD or else use empty.log
 # this is required for udev events where there is no media available
 # such as ejecting the drive
 
-if [ -n "$ID_FS_LABEL" ]; then
+if [ "$LOG_SINGLE_FILE" == true ]; then
+	LOGFILE="ARM.log"
+else
+	if [ -n "$ID_FS_LABEL" ]; then
         LOGFILE=${ID_FS_LABEL}".log"
         elif [[ -n "$ID_CDROM_MEDIA_TRACK_COUNT_AUDIO" && $(which abcde-musicbrainz-tool) ]]; then
                 LOGFILE=$(abcde-musicbrainz-tool --device "$DEVNAME" | cut -f1 -d ' ')".log"
         elif [[ -n "$ID_CDROM_MEDIA_TRACK_COUNT_AUDIO" &&  $(which cd-discid) ]]; then
                 LOGFILE=$(cd-discid "$DEVNAME" | cut -f1 -d ' ')".log"
-else
+	else
         LOGFILE="empty.log"
+	fi
 fi
 
 # Set full logfile path

--- a/identify.sh
+++ b/identify.sh
@@ -11,6 +11,24 @@ source "$ARM_CONFIG"
 # shellcheck disable=SC1090
 source "$DISC_INFO"
 
+# Determine logfile name
+# use the label of the DVD/CD or else use empty.log
+# this is required for udev events where there is no media available
+# such as ejecting the drive
+
+if [ -n "$ID_FS_LABEL" ]; then
+        LOGFILE=${ID_FS_LABEL}".log"
+        elif [[ -n "$ID_CDROM_MEDIA_TRACK_COUNT_AUDIO" && $(which abcde-musicbrainz-tool) ]]; then
+                LOGFILE=$(abcde-musicbrainz-tool --device "$DEVNAME" | cut -f1 -d ' ')".log"
+        elif [[ -n "$ID_CDROM_MEDIA_TRACK_COUNT_AUDIO" &&  $(which cd-discid) ]]; then
+                LOGFILE=$(cd-discid "$DEVNAME" | cut -f1 -d ' ')".log"
+else
+        LOGFILE="empty.log"
+fi
+
+# Set full logfile path
+LOG=$LOGPATH$LOGFILE
+
 # Create log dir if needed
 mkdir -p "$LOGPATH"
 
@@ -109,7 +127,7 @@ if [ "$ID_FS_TYPE" == "udf" ]; then
 		fi
 	else
 		echo "ARM_CHECK_UDF is false, assuming udf is video" >> "$LOG"
-		/opt/arm/video_rip.sh "$LOG"
+		/opt/arm/video_rip.sh "UnknownTitle" "false" "unknown" "$LOG"
 	fi
 
 
@@ -117,7 +135,7 @@ elif [ -n "$ID_CDROM_MEDIA_TRACK_COUNT_AUDIO" ]; then
 	echo "identified audio" >> "$LOG"
 	abcde -d "$DEVNAME"
     if [ "$NOTIFY_RIP" = "true" ]; then
-	    echo /opt/arm/notify.sh "\"Audio Rip: ${ID_FS_LABEL} completed from ${DEVNAME}\"" |at -M now
+	    echo /opt/arm/notify.sh "\"Audio Rip: ${ID_FS_LABEL} completed from ${DEVNAME}\" \"$LOG\"" |at -M now
 	fi
 
 elif [ "$ID_FS_TYPE" == "iso9660" ]; then

--- a/notify.sh
+++ b/notify.sh
@@ -4,6 +4,7 @@
 # shellcheck disable=SC1091
 source "$ARM_CONFIG"
 MSG=$1
+LOG=$2
 
 {
 #Notification via pushbullet

--- a/video_rip.sh
+++ b/video_rip.sh
@@ -10,6 +10,7 @@ source "$DISC_INFO"
 VIDEO_TITLE=$1
 HAS_NICE_TITLE=$2
 VIDEO_TYPE=$3
+LOG=$4
 
 {
     echo "Starting video_rip.sh"
@@ -47,13 +48,13 @@ VIDEO_TYPE=$3
 	#eject $DEVNAME
 
     if [ "$NOTIFY_RIP" = "true" ]; then
-		echo /opt/arm/notify.sh "\"Ripped: ${VIDEO_TITLE} completed from ${DEVNAME} in ${RIPTIME}\"" |at -M now
+		echo /opt/arm/notify.sh "\"Ripped: ${VIDEO_TITLE} completed from ${DEVNAME} in ${RIPTIME}\" \"$LOG\""|at -M now
     fi
 
 	echo "STAT: ${ID_FS_LABEL} ripped in ${RIPTIME}" >> "$LOG"
 
-	echo "/opt/arm/video_transcode.sh \"$DEST\" \"$VIDEO_TITLE\" \"$HAS_NICE_TITLE\" \"$VIDEO_TYPE\" $TIMESTAMP"
-	echo "/opt/arm/video_transcode.sh \"$DEST\" \"$VIDEO_TITLE\" \"$HAS_NICE_TITLE\" \"$VIDEO_TYPE\" \"$TIMESTAMP\"" | batch
+	echo "/opt/arm/video_transcode.sh \"$DEST\" \"$VIDEO_TITLE\" \"$HAS_NICE_TITLE\" \"$VIDEO_TYPE\" \"$TIMESTAMP\" \"$LOG\"" 
+	echo "/opt/arm/video_transcode.sh \"$DEST\" \"$VIDEO_TITLE\" \"$HAS_NICE_TITLE\" \"$VIDEO_TYPE\" \"$TIMESTAMP\" \"$LOG\"" | batch
 
 	echo "${VIDEO_TITLE} sent to transcoding queue..." >> "$LOG"
 

--- a/video_transcode.sh
+++ b/video_transcode.sh
@@ -10,6 +10,7 @@ LABEL=$2
 HAS_NICE_TITLE=$3
 VIDEO_TYPE=$4
 TIMESTAMP=$5
+LOG=$6
 
 
 	TRANSSTART=$(date +%s);
@@ -300,6 +301,6 @@ echo "STAT: ${LABEL} transcoded in ${TRANSTIME}" >> "$LOG"
 #echo /opt/arm/rename.sh $DEST
 
 if [ "$NOTIFY_TRANSCODE" = "true" ]; then
-	echo /opt/arm/notify.sh "\"Transcode: ${LABEL} completed in ${TRANSTIME}\"" |at -M now
+	echo /opt/arm/notify.sh "\"Transcode: ${LABEL} completed in ${TRANSTIME}\" \"$LOG\""|at -M now
 fi
 


### PR DESCRIPTION
Fixes #89 and as a by product, gets the per disc logging (the purpose of the logic) working correctly! It accomplishes this by moving the logic to the identify.sh script. Whenever this calls another script, it passes the LOG variable to that script. I have edited each of these scripts to use this parameter, so all of a discs activity will be logged to its own file.

Adds a new variable to config.sample as well, `LOG_SINGLE_FILE`, which defaults to false. With false, you get per disc logging and empty disc goes to empty.log
If you set it to true, it will log **everything** to ARM.log, much like the behavior before with everything going to empty.log

I thought some people might like the option to keep an eye on a single log file vs individual and this was an easy way to offer that choice.


Lots of changes for this to several files, I have double checked as well as tested out all the different disc types and it is working in my tests. Please test as well!