### PR TITLE
Fix udev rules blocking udev settle service

### DIFF
--- a/51-automedia.rules
+++ b/51-automedia.rules
@@ -1,4 +1,4 @@
 # ID_CDROM_MEDIA_BD = Bluray
 # ID_CDROM_MEDIA_DVD = DVD
 # ID_CDROM_MEDIA_CD = CD
-ACTION=="change", SUBSYSTEM=="block", TAG+="systemd", RUN+="/bin/systemctl start arm@%k.service"
+ACTION=="change", SUBSYSTEM=="block", TAG+="systemd", KERNEL=="sr[0-9]*|vdisk*|xvd*", ENV{DEVTYPE}=="disk", RUN+="/bin/systemctl start arm@%k.service"


### PR DESCRIPTION
Fixes issue #101 by specifying the kernel target and devtype disk target.