### PR TITLE
[BUGFIX] CPU info not displayed when using rpi4

### DIFF
--- a/arm/models/system_info.py
+++ b/arm/models/system_info.py
@@ -43,7 +43,9 @@ class SystemInfo(db.Model):
             # Intel     model name  : Intel(R) Celeron(R) G4930T CPU @ 3.00GHz
             # amd       model name  : AMD Ryzen 5 3600 6-Core Processor
             # arm       model name  : ARMv8 Processor rev 3 (v8l)
-            regex_match = re.search(r"model name\s*:\s*(.*)", fulldump)
+            # arm alt  Model : Raspberry Pi 4 Model B Rev 1.2
+            regex_match = re.search(r"(?:model name|Model)\s*:\s*(.*)", fulldump, re.IGNORECASE)
+
             logging.debug(f"Regex output: {regex_match}")
             if regex_match:
                 self.cpu = regex_match.group(1)


### PR DESCRIPTION
# Description
Currently, CPU model won't be found when run on some Raspberrypis, the output of `cat /proc/cpuinfo` is slightly different under Rpi
I added a check for `Model` in the regex, It's after the initial check for `model name` so this shouldn't change anything for other installations. Tested/updated system info, and it now works correctly with the changes.

Fixes #1597 

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] Docker
- [x] Other - Rpi4 (Trixie)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Changed regex that checks the output of `cat /proc/cpuinfo` to find the correct model of cpu

# Logs
N/A