### PR TITLE
Fix formatting for Docker.md examples

### DIFF
--- a/arm_wiki/Docker.md
+++ b/arm_wiki/Docker.md
@@ -49,7 +49,7 @@ The script will now:
 
     3. To set the timezone, enter an acceptable value for `TZ`. If none is set, the default timezone is UTC.
 
-       Example: -e TZ=New_York`
+       Example: -e `TZ=New_York`
 
     4. Fill in the appropriate paths for the volumes being mounted. Only change the path on the left hand side, docker volumes are configured with "[local path]:[arm path]". More information about volumes is found below under the heading: [Understanding Docker Volumes for A.R.M.](#understanding-docker-volumes-for-arm)
 
@@ -63,7 +63,7 @@ The script will now:
 
    7. Set the name of the docker image, the default is below, but can be user configured.
       
-      Example: `--name "automatic-ripping-machine"`
+      Example: `--name "arm-rippers"`
    
    8. Save and close
 


### PR DESCRIPTION
# Title (remove section)
Proper formatting + docker container name fix - [DOCFIX]

# Description
Added a ` for proper formatting in the Docker.md file and changed the default docker container name from `automatic-ripping-machine` to `arm-rippers`

## Type of change

- [x] This change requires a documentation update

- [x] Docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Change-log

arm_wiki\Docker.md l. 52
arm_wiki\Docker.md l. 66
