### PR TITLE
Fix FFmpeg bluray and playlist support

### DIFF
--- a/arm/ripper/ffmpeg.py
+++ b/arm/ripper/ffmpeg.py
@@ -159,7 +159,7 @@ def parse_probe_output(json_str, input_filename="", title_override=0):
             'fps': fps,
             'aspect': aspect,
             'codec': stream.get('codec_name'),
-            # ffmpeg can select select during transcode step
+            # ffmpeg can select stream during transcode step
             'stream_index': stream.get('index'),
             'filename': input_filename
         })


### PR DESCRIPTION
# Fix FFMPEG not working with blurays and playlists

Patch or Bugfix - Bugfix

## Description

Fix an issue with the `ffmpeg` support where it would not work properly on blurays that contained multiple titles in the form of playlists. The support for `ffmpeg` was introduced recently but does not take into account that transcoding titles from blurays requires the `bluray` protocol in the input file argument and the `playlist` argument for individual file transcoding.

Fixes #1628 (ARM fails during FFMPEG transcode during ffprobe step when using backup RIPMETHOD_BR)

## Type of change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

* Tested by inserting a disc into the tray and having it get picked up by udev
* Tested by running the ripper manually using `runui.py`
* Tested by importing the ffmpeg module into a python3 repl and running the `run_transcode_cmd`

Relevant details for my test configuration:

* Uses an Intel Arc GPU for transcoding. Uses the following config values:

<img width="1513" height="183" alt="image" src="https://github.com/user-attachments/assets/c3dec2ed-f365-425e-91d7-20c8835e5b2e" />



- [X] Docker
- [ ] Other (Please state here)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- FFmpeg support now works with blurays and playlists

# Logs
- Attached as a ZIP since the DEBUG level includes so much info 
[INCEPTION_176627213768.zip](https://github.com/user-attachments/files/24275591/INCEPTION_176627213768.zip)

## A Note on QSV Support

### Summary

Below is an investigation into the correct cli (parameters) to get FFMPEG to use the Intel ARC GPU with the AV1 QSV encoder. Below uses notes from the [FFMPEG](https://trac.ffmpeg.org/wiki/Hardware/QuickSync) documentation.

### CLI Investigation

The correct command for transcoding with qsv (av1) for Inception (playlist 100) - `playlist` and `-i bluray` are required to properly rip playlists from a backed up bluray.

```shell
ffmpeg -init_hw_device qsv=hw -filter_hw_device hw -playlist 100 -i bluray:/home/arm/media/raw/Inception_176599407504 -vf hwupload=extra_hw_frames=64,format=qsv -c:v av1_qsv -b:v 5M -maxrate 5M '/home/arm/media/transcode/movies/Inception (2010)_176599407504/title_100.mkv'
```
