### PR TITLE
[BUGFIX] fix ci greetings job

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/first-interaction@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: 'If youre having issues, please remember to read the [wiki](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/FAQ) and follow the instructions carefully'
-        pr-message: 'Thanks for submitting a PR, please try to keep PR as small as possible for faster merge times'
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: 'If youre having issues, please remember to read the [wiki](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/FAQ) and follow the instructions carefully'
+        pr_message: 'Thanks for submitting a PR, please try to keep PR as small as possible for faster merge times'


### PR DESCRIPTION
# Description
The `greetings.yml` ci job fails because the library now expects keys as `kebab-case` rather than `snake_case`. You can see that the `first-interaction` repo itself made a similar change in the v3.1 release ([PR](https://github.com/actions/first-interaction/pull/344/changes))

Before: `Error: Input required and not supplied: issue_message` error (for example, see [here](https://github.com/automatic-ripping-machine/automatic-ripping-machine/actions/runs/20664860949/job/59334892125?pr=1660)).
After: CI job no longer gets that error.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
CI job no longer gets the `Error: Input required and not supplied: issue_message` error.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

- update greetings.yml to use correct keys

# Logs
N/A