### PR TITLE
[BUGFIX] use Python instead of `tail`

### DIFF
--- a/arm/ui/json_api.py
+++ b/arm/ui/json_api.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import re
 import html
+from collections import deque
 from pathlib import Path
 import datetime
 import psutil
@@ -247,18 +248,18 @@ def calc_process_time(starttime, cur_iter, max_iter):
     return f"{str(test).split('.', maxsplit=1)[0]} - @{finish_time.strftime('%H:%M:%S')}"
 
 
-def read_log_line(log_file):
+def read_log_line(log_file: os.PathLike):
     """
-    Try to catch if the logfile gets delete before the job is finished\n
-    :param log_file:
-    :return:
+    :param log_file: path to log file
+    :return: the last 20 lines of the file at ``log_file``
     """
     try:
-        line = subprocess.check_output(['tail', '-n', '20', log_file]).splitlines()
-    except subprocess.CalledProcessError:
+        with open(log_file, encoding="utf8", errors="ignore") as read_log_file:
+            lines = deque(read_log_file, maxlen=20)
+    except OSError:
         app.logger.debug(f"Error while reading {log_file}, unable to calculate ETA")
-        line = ["", ""]
-    return line
+        lines = ["", ""]
+    return lines
 
 
 def read_all_log_lines(log_file):


### PR DESCRIPTION
# Description
`tail` exhibits significant performance issues on files above the ~20MiB range, which is reached quite easily on the DEBUG loglevel, because of the makemkv messaging. This PR replaces the call to `tail` with a very simple native implementation, which is orders of magnitude faster.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ripped a disc, used the "tail" option on the logs.

- [x] Docker
- [x] Other (My own NixOS module)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Logs

[DVDVIDEO_177039962042.log](https://github.com/user-attachments/files/25134602/DVDVIDEO_177039962042.log)
