### PR TITLE
[BUGFIX] Prevent fatal error due to uparsed lines when makemkvcon rips successfully (#1688)

### DIFF
--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -1191,7 +1191,7 @@ def run(options, select):
                 yield data
     if proc.returncode:
         raise MakeMkvRuntimeError(proc.returncode, cmd, output=os.linesep.join(buffer))
-    if buffer:
+    if buffer and proc.returncode:
         logging.warning(f"Cannot parse {len(buffer)} lines: {os.linesep.join(buffer)}")
         raise MakeMkvRuntimeError(proc.returncode, cmd, output=os.linesep.join(buffer))
     logging.info("MakeMKV exits gracefully.")


### PR DESCRIPTION
[BUGFIX] Prevent fatal error due to uparsed lines when makemkvcon rips successfully (#1688)


# Description
Check for buffer content only if the process returns an error.
Created Pull Request for suggestion by @swolfe2

Fixes #1688 BUG: Parser Fragility causes Fatal Error on successful rips (makemkv.py)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Ripped a disc that would generate MakeMKV errors, result was ARM fatal error.
2. Applied the proposed patch change.
3. Ripped the same disc that would generate MakeMKV errors, result was successful rip and transcode.

- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

- Check for buffer content only if the MakeMKV process returns an error.

# Logs

Error case demonstrating the issue that with MakeMKV debug logging, MakeMKV rip was successful (exit 0) yet ARM throws fatal error.
ARM and MakeMKV debug logs attached:
[logs-Alien3-ng.zip](https://github.com/user-attachments/files/25191320/logs-Alien3-ng.zip)

No error case demonstrating that without MakeMKV debug logging, MakeMKV rip was successful (exit 0) and ARM finished successfully.
ARM and MakeMKV debug logs attached:
[logs-Alien3-ok-no-debug.zip](https://github.com/user-attachments/files/25196339/logs-Alien3-ok-no-debug.zip)

No error case demonstrating patch effectiveness with MakeMKV debug logging, MakeMKV rip was successful (exit 0) and ARM finished successfully.
[logs-Alien3-ok-debug.zip](https://github.com/user-attachments/files/25196351/logs-Alien3-ok-debug.zip)
