### PR TITLE
[BUGFIX] Update Apprise docs, correcting gotify instructions to match apprise syntax

### DIFF
--- a/arm_wiki/Config-apprise.yaml.md
+++ b/arm_wiki/Config-apprise.yaml.md
@@ -94,10 +94,14 @@ If you would like a services added to ARM that is not yet listed here, please op
 
 ## Service Specific Configurations
 
-- The Gotify settings expect a server address in one of the following formats:
+### **Gotify**
+
+The Gotify settings expect a server address in one of the following formats:
+
 ```
 gotifys://[GOTIFY-ADDRESS]
 gotify://[GOTIFY-ADDRESS]
 ```
+
 - Use **gotifys** if your Gotify server is configured with SSL/TLS (**secure connection**).
 - Use **gotify** if your Gotify server is **not** configured with SSL/TLS (**insecure connection**).


### PR DESCRIPTION
# Description
Apprise wiki instructs use of http(s), but the [apprise syntax](https://appriseit.com/services/gotify/) is gotify(s). [apprise_bulk.py](https://github.com/automatic-ripping-machine/automatic-ripping-machine/blob/9850e690377d8006db72ddc4e751b7c585801d0d/arm/ripper/apprise_bulk.py) doesn't parse the gotify string and choose the proper apprise syntax like it does for ntfy: https://github.com/automatic-ripping-machine/automatic-ripping-machine/blob/9850e690377d8006db72ddc4e751b7c585801d0d/arm/ripper/apprise_bulk.py#L113-L118

https://github.com/automatic-ripping-machine/automatic-ripping-machine/blob/9850e690377d8006db72ddc4e751b7c585801d0d/arm/ripper/apprise_bulk.py#L20

Fixes #1714

## Type of change
Please delete options that are not relevant.

- [X] This change requires a documentation update

# How Has This Been Tested?

I tested using ARM in a docker container and gotify in a docker container behind nginx reverse proxy with SSL/TSL. None of the following worked:

- `http://LOCAL_IP`
- `https://LOCAL_IP`
- `https://REVERSE-PROXY_URL`

- [X] Docker

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works

# Changelog:

Simply updated the wiki documentation to change `http` to `gotify` and `https` to `gotifys`.

# Logs

Snippet from a rip log:

```
03-05-2026 20:12:32 ARM: DEBUG: utils.database_adder: Trying to add Notifications
03-05-2026 20:12:32 ARM: DEBUG: utils.database_adder: successfully written Notifications to the database
03-05-2026 20:12:32 ARM: DEBUG: apprise_bulk.apprise_notify: Sent apprise to GOTIFY_TOKEN was successful
03-05-2026 20:12:32 ARM: DEBUG: utils.notify: apprise-config: /etc/arm/config/apprise.yaml
```

gotify server log (disregard incorrect TZ):

```
2026-03-06T01:12:32Z | 200 |   20.078093ms |      172.25.0.2 | POST     "/message"
2026-03-06T01:12:47Z | 200 |     3.05633ms |      172.25.0.2 | GET      "/application"
```

`apprise.yaml`

```
GOTIFY_TOKEN: "REDACTED"
GOTIFY_HOST: "gotifys://gotify.my.domain"
```